### PR TITLE
Update Shield version and improve JWT token validation

### DIFF
--- a/src/Auth.php
+++ b/src/Auth.php
@@ -41,7 +41,7 @@ class Auth
     /**
      * The current version of CodeIgniter Shield
      */
-    public const SHIELD_VERSION = '1.0.5';
+    public const SHIELD_VERSION = '3.0.2';
 
     protected ?UserProviderInterface $userProvider = null;
     protected ?Authentication $authenticate        = null;

--- a/src/Authentication/Authenticators/JWT.php
+++ b/src/Authentication/Authenticators/JWT.php
@@ -59,6 +59,16 @@ class JWT extends Base implements AuthenticatorInterface
             $credentials = ['token' => $this->getBearerFromHeader()];
         }
 
+        if (! array_key_exists('token', $credentials) || empty($credentials['token'])) {
+            return new Result([
+                'success' => false,
+                'reason'  => lang(
+                    'Auth.noToken',
+                    [service('settings')->get('Auth.authenticatorHeader')[$this->method]],
+                ),
+            ]);
+        }
+
         return $this->checkLogin($credentials);
     }
 


### PR DESCRIPTION
Bumped SHIELD_VERSION to 3.0.2 in Auth.php. Added a check in JWT authenticator to return a failure result if the token is missing or empty, improving error handling for missing JWT tokens.