### PR TITLE
Invoke controller fail method via reflection

### DIFF
--- a/src/Services/ExceptionHandler.php
+++ b/src/Services/ExceptionHandler.php
@@ -16,7 +16,7 @@ namespace Daycry\Auth\Services;
 use CodeIgniter\HTTP\RequestInterface;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\Validation\Validation;
-use Exception;
+use ReflectionMethod;
 use ReflectionProperty;
 use Throwable;
 
@@ -61,7 +61,12 @@ class ExceptionHandler
 
         // Handle response based on controller capabilities and request type
         if ($controller && method_exists($controller, 'fail')) {
-            return $controller->fail($message, $code);
+            $reflection = new ReflectionMethod($controller, 'fail');
+            if (! $reflection->isPublic()) {
+                $reflection->setAccessible(true);
+            }
+
+            return $reflection->invoke($controller, $message, $code);
         }
 
         // Check if request is AJAX (assuming IncomingRequest which has isAJAX method)


### PR DESCRIPTION
Updated exception handling to use ReflectionMethod when invoking the controller's fail method, ensuring it can be called even if not public. This improves flexibility in handling exceptions for controllers with non-public fail methods.