### PR TITLE
Switch to CI exceptions and refine auth actions

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,18 +13,6 @@ parameters:
 			path: src/Authentication/Actions/Email2FA.php
 
 		-
-			rawMessage: Instantiated class Daycry\Exceptions\Exceptions\RuntimeException not found.
-			identifier: class.notFound
-			count: 4
-			path: src/Authentication/Actions/Email2FA.php
-
-		-
-			rawMessage: Throwing object of an unknown class Daycry\Exceptions\Exceptions\RuntimeException.
-			identifier: class.notFound
-			count: 4
-			path: src/Authentication/Actions/Email2FA.php
-
-		-
 			rawMessage: Call to function model with Daycry\Auth\Models\UserIdentityModel::class is discouraged.
 			identifier: codeigniter.factoriesClassConstFetch
 			count: 2
@@ -37,50 +25,8 @@ parameters:
 			path: src/Authentication/Actions/EmailActivator.php
 
 		-
-			rawMessage: Instantiated class Daycry\Exceptions\Exceptions\LogicException not found.
-			identifier: class.notFound
-			count: 1
-			path: src/Authentication/Actions/EmailActivator.php
-
-		-
-			rawMessage: Instantiated class Daycry\Exceptions\Exceptions\RuntimeException not found.
-			identifier: class.notFound
-			count: 3
-			path: src/Authentication/Actions/EmailActivator.php
-
-		-
-			rawMessage: Throwing object of an unknown class Daycry\Exceptions\Exceptions\LogicException.
-			identifier: class.notFound
-			count: 1
-			path: src/Authentication/Actions/EmailActivator.php
-
-		-
-			rawMessage: Throwing object of an unknown class Daycry\Exceptions\Exceptions\RuntimeException.
-			identifier: class.notFound
-			count: 3
-			path: src/Authentication/Actions/EmailActivator.php
-
-		-
 			rawMessage: Call to function model with Daycry\Auth\Models\UserIdentityModel::class is discouraged.
 			identifier: codeigniter.factoriesClassConstFetch
-			count: 3
-			path: src/Authentication/Actions/Totp2FA.php
-
-		-
-			rawMessage: Instantiated class Daycry\Exceptions\Exceptions\RuntimeException not found.
-			identifier: class.notFound
-			count: 3
-			path: src/Authentication/Actions/Totp2FA.php
-
-		-
-			rawMessage: PHPDoc tag @throws with type Daycry\Exceptions\Exceptions\RuntimeException is not subtype of Throwable
-			identifier: throws.notThrowable
-			count: 1
-			path: src/Authentication/Actions/Totp2FA.php
-
-		-
-			rawMessage: Throwing object of an unknown class Daycry\Exceptions\Exceptions\RuntimeException.
-			identifier: class.notFound
 			count: 3
 			path: src/Authentication/Actions/Totp2FA.php
 
@@ -1211,18 +1157,6 @@ parameters:
 			identifier: staticMethod.notFound
 			count: 1
 			path: src/Services/RequestLogger.php
-
-		-
-			rawMessage: Instantiated class Daycry\Exceptions\Exceptions\LogicException not found.
-			identifier: class.notFound
-			count: 1
-			path: src/Test/MockInputOutput.php
-
-		-
-			rawMessage: Throwing object of an unknown class Daycry\Exceptions\Exceptions\LogicException.
-			identifier: class.notFound
-			count: 1
-			path: src/Test/MockInputOutput.php
 
 		-
 			rawMessage: 'Call to method Daycry\Auth\Result::isOK() with incorrect case: isOk'

--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Daycry\Auth\Authentication\Actions;
 
+use CodeIgniter\Exceptions\RuntimeException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\I18n\Time;
@@ -23,7 +24,6 @@ use Daycry\Auth\Interfaces\ActionInterface;
 use Daycry\Auth\Libraries\Utils;
 use Daycry\Auth\Models\UserIdentityModel;
 use Daycry\Auth\Traits\Viewable;
-use Daycry\Exceptions\Exceptions\RuntimeException;
 
 /**
  * Class Email2FA

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Daycry\Auth\Authentication\Actions;
 
+use CodeIgniter\Exceptions\LogicException;
 use CodeIgniter\Exceptions\PageNotFoundException;
+use CodeIgniter\Exceptions\RuntimeException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\Response;
@@ -25,8 +27,6 @@ use Daycry\Auth\Interfaces\ActionInterface;
 use Daycry\Auth\Libraries\Utils;
 use Daycry\Auth\Models\UserIdentityModel;
 use Daycry\Auth\Traits\Viewable;
-use Daycry\Exceptions\Exceptions\LogicException;
-use Daycry\Exceptions\Exceptions\RuntimeException;
 
 class EmailActivator implements ActionInterface
 {

--- a/src/Authentication/Actions/Totp2FA.php
+++ b/src/Authentication/Actions/Totp2FA.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Daycry\Auth\Authentication\Actions;
 
+use CodeIgniter\Exceptions\RuntimeException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
 use Daycry\Auth\Authentication\Authenticators\Session;
@@ -23,7 +24,6 @@ use Daycry\Auth\Interfaces\ActionInterface;
 use Daycry\Auth\Libraries\TOTP;
 use Daycry\Auth\Models\UserIdentityModel;
 use Daycry\Auth\Traits\Viewable;
-use Daycry\Exceptions\Exceptions\RuntimeException;
 
 /**
  * Class Totp2FA

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -15,6 +15,8 @@ namespace Daycry\Auth\Config;
 
 use CodeIgniter\Config\BaseConfig;
 use Daycry\Auth\Authentication\Actions\Email2FA;
+use Daycry\Auth\Authentication\Actions\EmailActivator;
+use Daycry\Auth\Authentication\Actions\Totp2FA;
 use Daycry\Auth\Authentication\Authenticators\AccessToken;
 use Daycry\Auth\Authentication\Authenticators\JWT;
 use Daycry\Auth\Authentication\Authenticators\Session;
@@ -172,15 +174,21 @@ class Auth extends BaseConfig
      *
      * You must register actions in the order of the actions to be performed.
      *
-     * Available actions with Auth:
-     * - register: \Daycry\Auth\Authentication\Actions\EmailActivator::class
-     * - login:    \Daycry\Auth\Authentication\Actions\Email2FA::class
+     * Post-authentication actions triggered after login or register.
+     * Set a key to null to disable the action for that event.
+     *
+     * Available action classes:
+     * - Email2FA::class       — sends a 6-digit code by email (login)
+     * - Totp2FA::class        — validates an RFC 6238 TOTP code (login)
+     * - EmailActivator::class — requires email confirmation before login (register)
+     *
+     * Only one action per event is supported.
      *
      * @var array<string, class-string<ActionInterface>|null>
      */
     public array $actions = [
-        'register' => null,
-        'login'    => Email2FA::class,
+        'register' => null,            // e.g. EmailActivator::class
+        'login'    => null,            // e.g. Email2FA::class or Totp2FA::class
     ];
 
     /**

--- a/src/Test/MockInputOutput.php
+++ b/src/Test/MockInputOutput.php
@@ -14,10 +14,10 @@ declare(strict_types=1);
 namespace Daycry\Auth\Test;
 
 use CodeIgniter\CLI\CLI;
+use CodeIgniter\Exceptions\LogicException;
 use CodeIgniter\Test\Filters\CITestStreamFilter;
 use CodeIgniter\Test\PhpStreamWrapper;
 use Daycry\Auth\Commands\Utils\InputOutput;
-use Daycry\Exceptions\Exceptions\LogicException;
 
 final class MockInputOutput extends InputOutput
 {


### PR DESCRIPTION
Replace references to Daycry\Exceptions with CodeIgniter exception classes (RuntimeException and LogicException) in Email2FA, EmailActivator, Totp2FA, and MockInputOutput. Update Config/Auth to import EmailActivator and Totp2FA, improve the actions docblock, and set clearer defaults (login/register) for post-auth actions. Clean up phpstan-baseline.neon to remove obsolete missing-class/throws entries related to the removed Daycry exception references.