### PR TITLE
Add login/register route helpers; update baseline

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -499,18 +499,6 @@ parameters:
 			path: src/Controllers/JwtController.php
 
 		-
-			rawMessage: 'Call to an undefined method Daycry\Auth\Config\Auth::loginRoute().'
-			identifier: method.notFound
-			count: 2
-			path: src/Controllers/LoginController.php
-
-		-
-			rawMessage: 'Call to an undefined method Daycry\Auth\Config\Auth::loginRoute().'
-			identifier: method.notFound
-			count: 2
-			path: src/Controllers/MagicLinkController.php
-
-		-
 			rawMessage: Call to function model with Daycry\Auth\Models\LoginModel::class is discouraged.
 			identifier: codeigniter.factoriesClassConstFetch
 			count: 1
@@ -527,12 +515,6 @@ parameters:
 			identifier: function.internal
 			count: 1
 			path: src/Controllers/MagicLinkController.php
-
-		-
-			rawMessage: 'Call to an undefined method Daycry\Auth\Config\Auth::loginPage().'
-			identifier: method.notFound
-			count: 1
-			path: src/Controllers/OauthController.php
 
 		-
 			rawMessage: Call to function model with Daycry\Auth\Models\LoginModel::class is discouraged.
@@ -557,12 +539,6 @@ parameters:
 			identifier: function.internal
 			count: 1
 			path: src/Controllers/PasswordResetController.php
-
-		-
-			rawMessage: 'Call to an undefined method Daycry\Auth\Config\Auth::registerRoute().'
-			identifier: method.notFound
-			count: 3
-			path: src/Controllers/RegisterController.php
 
 		-
 			rawMessage: 'Call to function assert() with false and ''Config Auth…'' will always evaluate to false.'

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -538,6 +538,32 @@ class Auth extends BaseConfig
     public array $excludeMethods = ['initController', '_remap'];
 
     /**
+     * Returns the URL of the login page.
+     * Used to redirect back to login on error or when auth is required.
+     */
+    public function loginRoute(): string
+    {
+        return $this->getUrl('login');
+    }
+
+    /**
+     * Returns the URL of the registration page.
+     * Used to redirect back to register on validation errors.
+     */
+    public function registerRoute(): string
+    {
+        return $this->getUrl('register');
+    }
+
+    /**
+     * Alias for loginRoute(). Returns the URL of the login page.
+     */
+    public function loginPage(): string
+    {
+        return $this->loginRoute();
+    }
+
+    /**
      * Returns the URL that a user should be redirected
      * to after a successful login.
      */


### PR DESCRIPTION
Add three URL helper methods to Auth config: loginRoute() and registerRoute() which return getUrl('login') / getUrl('register'), and loginPage() as an alias to loginRoute(). These provide explicit methods used for redirects after auth events. Remove corresponding phpstan baseline suppressions for undefined methods (loginRoute, loginPage, registerRoute) so static analysis no longer needs to ignore those reports in controllers (LoginController, MagicLinkController, OauthController, RegisterController).