### PR TITLE
Make TOTP 2FA optional; add tests and session cleanup

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1159,6 +1159,12 @@ parameters:
 			path: tests/Authentication/Actions/Email2FATest.php
 
 		-
+			rawMessage: 'Call to internal static method CodeIgniter\Config\Factories::injectMock() from outside its root namespace CodeIgniter.'
+			identifier: staticMethod.internal
+			count: 4
+			path: tests/Authentication/Actions/Totp2FATest.php
+
+		-
 			rawMessage: Call to unknown service method 'settings'.
 			identifier: codeigniter.unknownServiceMethod
 			count: 1

--- a/src/Authentication/Actions/Totp2FA.php
+++ b/src/Authentication/Actions/Totp2FA.php
@@ -28,20 +28,21 @@ use Daycry\Auth\Traits\Viewable;
 /**
  * Class Totp2FA
  *
- * Provides TOTP (RFC 6238 / Google Authenticator) second-factor authentication.
+ * Optional TOTP (RFC 6238 / Google Authenticator) second-factor authentication.
  *
- * Usage:
- *   In Auth config set `'login' => Totp2FA::class` inside `$actions`.
- *   Users must have TOTP configured via `$user->enableTotp($issuer)` before this
- *   action is triggered.
+ * Behaviour when set as `'login' => Totp2FA::class` in Auth::$actions:
+ *   - User HAS TOTP configured → code entry form is shown before completing login.
+ *   - User has NO TOTP configured → action is silently skipped, login proceeds normally.
+ *
+ * Users enable/disable TOTP from their account security settings via
+ * UserSecurityController (totpSetup / totpDisable).
  */
 class Totp2FA implements ActionInterface
 {
     use Viewable;
 
     /**
-     * The identity type used to mark that a TOTP verification is pending.
-     * The permanent TOTP secret is stored under IdentityType::TOTP_SECRET.
+     * Identity type for the pending-login marker.
      */
     private string $type = IdentityType::TOTP->value;
 
@@ -96,7 +97,7 @@ class Totp2FA implements ActionInterface
             return $this->view(setting('Auth.views')['action_totp_2fa_verify']);
         }
 
-        // Remove the pending marker identity and complete login
+        // Remove the pending marker and complete login
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);
         $identityModel->deleteIdentitiesByType($user, $this->type);
@@ -107,31 +108,27 @@ class Totp2FA implements ActionInterface
     }
 
     /**
-     * Creates a temporary pending identity so the Session authenticator
-     * knows TOTP verification is required for this login attempt.
+     * Creates the pending marker so Session knows TOTP verification is required.
      *
-     * @return string The identity secret (not used for TOTP but required by the interface)
+     * If the user has no confirmed TOTP secret the method returns early without
+     * inserting a marker. Session::setAuthAction() will find nothing and
+     * hasAction() will return false, so the login completes normally.
      *
-     * @throws RuntimeException if the user has not configured TOTP
+     * @return string 'totp' when action is active, '' when skipped.
      */
     public function createIdentity(User $user): string
     {
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);
 
-        // Ensure the user has a permanent TOTP secret configured
-        $totpSecret = $identityModel->getIdentityByType($user, IdentityType::TOTP_SECRET->value);
-
-        if (! $totpSecret instanceof UserIdentity) {
-            throw new RuntimeException(
-                'User has not configured TOTP 2FA. Call $user->enableTotp($issuer) first.',
-            );
-        }
-
-        // Remove any stale pending TOTP identity
+        // Remove any stale marker from a previous attempt
         $identityModel->deleteIdentitiesByType($user, $this->type);
 
-        // Create a marker identity (secret field is unused — verification uses the permanent secret)
+        // Only activate the action for users who have confirmed TOTP
+        if (! $user->hasTotpEnabled()) {
+            return '';
+        }
+
         $identityModel->insert([
             'user_id' => $user->id,
             'type'    => $this->type,

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -510,6 +510,13 @@ class Session extends Base implements AuthenticatorInterface
      */
     public function completeLogin(User $user): void
     {
+        // Ensure no pending-action state survives in the session.
+        // This is critical for actions (e.g. Totp2FA) that call
+        // completeLogin() directly after verifying their own code,
+        // because those actions don't go through checkAction().
+        $this->removeSessionKey('auth_action');
+        $this->removeSessionKey('auth_action_message');
+
         $this->userState = AuthenticationState::LOGGED_IN;
 
         // a successful login
@@ -589,7 +596,18 @@ class Session extends Base implements AuthenticatorInterface
         $action = Factories::actions($actionClass); // @phpstan-ignore-line
 
         // Create identity for the action.
-        $action->createIdentity($user);
+        $secret = $action->createIdentity($user);
+
+        // An empty return value means the action decided to skip itself for this user
+        // (e.g. Totp2FA when the user has no TOTP configured).
+        // Clear any stale auth_action session key that setAuthAction() may have set
+        // earlier in login() from a leftover DB marker.
+        if ($secret === '') {
+            $this->removeSessionKey('auth_action');
+            $this->removeSessionKey('auth_action_message');
+
+            return false;
+        }
 
         $this->setAuthAction();
 

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -326,6 +326,8 @@ class Auth extends BaseConfig
         'force-password-reset' => '\Daycry\Auth\Views\force_password_reset',
         // Email change confirmation (sent to new address)
         'email-change-email' => '\Daycry\Auth\Views\Email\email_change_email',
+        // User security overview (device sessions + TOTP status)
+        'security_overview' => '\Daycry\Auth\Views\profile\security',
     ];
 
     /**

--- a/src/Controllers/UserSecurityController.php
+++ b/src/Controllers/UserSecurityController.php
@@ -59,7 +59,7 @@ class UserSecurityController extends BaseAuthController
         $sessions   = $deviceModel->getActiveForUser($user);
         $currentSid = session_id();
 
-        return $this->view('Daycry\Auth\Views\profile\security', [
+        return $this->view(setting('Auth.views')['security_overview'], [
             'sessions'    => $sessions,
             'currentSid'  => $currentSid,
             'totpEnabled' => $user->hasTotpEnabled(),
@@ -122,7 +122,7 @@ class UserSecurityController extends BaseAuthController
         $otpAuthUrl = $user->enableTotp();
         $secret     = $user->getTotpSecret();
 
-        return $this->view('Daycry\Auth\Views\totp_setup_show', [
+        return $this->view(setting('Auth.views')['action_totp_setup_show'], [
             'otpAuthUrl' => $otpAuthUrl,
             'secret'     => $secret ?? '',
             'qrCodeUrl'  => TOTP::getQRCodeUrl($otpAuthUrl),
@@ -146,7 +146,7 @@ class UserSecurityController extends BaseAuthController
                 ->with('error', lang('Auth.totpSetupInvalidCode'));
         }
 
-        return $this->view('Daycry\Auth\Views\totp_setup_success', [
+        return $this->view(setting('Auth.views')['action_totp_setup_success'], [
             'redirectUrl' => url_to('security'),
         ]);
     }

--- a/src/Traits/HasTotp.php
+++ b/src/Traits/HasTotp.php
@@ -42,11 +42,15 @@ trait HasTotp
     }
 
     /**
-     * Returns true if the user has TOTP 2FA configured.
+     * Returns true if the user has a confirmed TOTP 2FA secret.
+     * A secret stored during enrollment but not yet verified (name='totp_unverified')
+     * is NOT considered enabled.
      */
     public function hasTotpEnabled(): bool
     {
-        return $this->getTotpIdentity() instanceof UserIdentity;
+        $identity = $this->getTotpIdentity();
+
+        return $identity instanceof UserIdentity && $identity->name === 'totp';
     }
 
     /**

--- a/tests/Authentication/Actions/Totp2FATest.php
+++ b/tests/Authentication/Actions/Totp2FATest.php
@@ -1,0 +1,298 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Authentication\Actions;
+
+use CodeIgniter\Config\Factories;
+use CodeIgniter\Test\Mock\MockEvents;
+use Config\Services;
+use Daycry\Auth\Authentication\Actions\Totp2FA;
+use Daycry\Auth\Authentication\Authentication;
+use Daycry\Auth\Authentication\Authenticators\Session;
+use Daycry\Auth\Config\Auth;
+use Daycry\Auth\Enums\IdentityType;
+use Daycry\Auth\Libraries\TOTP;
+use Daycry\Auth\Models\UserIdentityModel;
+use Daycry\Auth\Models\UserModel;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\FakeUser;
+
+/**
+ * @internal
+ */
+final class Totp2FATest extends DatabaseTestCase
+{
+    use FakeUser;
+
+    private Session $authenticator;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpFakeUser();
+
+        // Set up the session authenticator
+        $config = new Auth();
+        $auth   = new Authentication($config);
+        $auth->setProvider(model(UserModel::class));
+
+        /** @var Session $authenticator */
+        $authenticator       = $auth->factory('session');
+        $this->authenticator = $authenticator;
+
+        $events = new MockEvents();
+        Services::injectMock('events', $events);
+
+        // Set a known email on the user
+        $this->user->email = 'foo@example.com';
+        model(UserModel::class)->save($this->user);
+
+        // Truncate identities to avoid unique constraint conflicts
+        $this->db->table($this->tables['identities'])->truncate();
+
+        // Create email identity for the user
+        model(UserIdentityModel::class)->createEmailIdentity($this->user, [
+            'email'    => 'foo@example.com',
+            'password' => 'secret123',
+        ]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Unit: createIdentity()
+    // -----------------------------------------------------------------------
+
+    public function testCreateIdentityReturnsEmptyForUserWithoutTotp(): void
+    {
+        $action = new Totp2FA();
+        $result = $action->createIdentity($this->user);
+
+        $this->assertSame('', $result, 'createIdentity() must return empty string when user has no TOTP configured');
+    }
+
+    public function testCreateIdentityReturnsTotpTypeForUserWithTotp(): void
+    {
+        // Configure TOTP for the user
+        $this->user->enableTotp('TestApp');
+
+        $action = new Totp2FA();
+        $result = $action->createIdentity($this->user);
+
+        $this->assertSame('totp', $result, 'createIdentity() must return "totp" when user has TOTP configured');
+    }
+
+    public function testCreateIdentityInsertsMarkerForUserWithTotp(): void
+    {
+        $this->user->enableTotp('TestApp');
+
+        $action = new Totp2FA();
+        $action->createIdentity($this->user);
+
+        $this->seeInDatabase($this->tables['identities'], [
+            'user_id' => $this->user->id,
+            'type'    => IdentityType::TOTP->value,
+            'name'    => 'totp_pending',
+        ]);
+    }
+
+    public function testCreateIdentityDoesNotInsertMarkerForUserWithoutTotp(): void
+    {
+        $action = new Totp2FA();
+        $action->createIdentity($this->user);
+
+        $this->dontSeeInDatabase($this->tables['identities'], [
+            'user_id' => $this->user->id,
+            'type'    => IdentityType::TOTP->value,
+        ]);
+    }
+
+    public function testCreateIdentityDeletesStaleMarker(): void
+    {
+        // Insert a stale marker manually
+        model(UserIdentityModel::class)->insert([
+            'user_id' => $this->user->id,
+            'type'    => IdentityType::TOTP->value,
+            'name'    => 'totp_pending',
+            'secret'  => 'totp',
+        ]);
+
+        // User has no TOTP secret configured
+        $action = new Totp2FA();
+        $action->createIdentity($this->user);
+
+        // Stale marker should be gone and no new one inserted
+        $this->dontSeeInDatabase($this->tables['identities'], [
+            'user_id' => $this->user->id,
+            'type'    => IdentityType::TOTP->value,
+        ]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Login flow: user WITHOUT TOTP, Totp2FA set as login action
+    // -----------------------------------------------------------------------
+
+    public function testLoginFlowWithoutTotpCompletesLogin(): void
+    {
+        // Enable Totp2FA action
+        /** @var Auth $config */
+        $config          = config('Auth');
+        $config->actions = ['login' => Totp2FA::class, 'register' => null];
+        Factories::injectMock('config', 'Auth', $config);
+
+        // Attempt login — user has NO TOTP configured
+        $result = $this->authenticator->attempt([
+            'email'    => $this->user->email,
+            'password' => 'secret123',
+        ]);
+
+        $this->assertTrue($result->isOK(), 'Attempt should succeed');
+
+        // User should be FULLY logged in (not pending)
+        $this->assertTrue($this->authenticator->loggedIn(), 'User should be logged in');
+        $this->assertFalse($this->authenticator->isPending(), 'User should NOT be in pending state');
+    }
+
+    public function testLoginFlowWithoutTotpAndStaleMarkerCompletesLogin(): void
+    {
+        // Enable Totp2FA action
+        /** @var Auth $config */
+        $config          = config('Auth');
+        $config->actions = ['login' => Totp2FA::class, 'register' => null];
+        Factories::injectMock('config', 'Auth', $config);
+
+        // Insert a stale totp pending marker (simulates abandoned previous login)
+        model(UserIdentityModel::class)->insert([
+            'user_id' => $this->user->id,
+            'type'    => IdentityType::TOTP->value,
+            'name'    => 'totp_pending',
+            'secret'  => 'totp',
+            'extra'   => 'You need to enter your TOTP code.',
+        ]);
+
+        // Attempt login — user has NO TOTP configured, but stale DB marker exists
+        $result = $this->authenticator->attempt([
+            'email'    => $this->user->email,
+            'password' => 'secret123',
+        ]);
+
+        $this->assertTrue($result->isOK(), 'Attempt should succeed');
+
+        // User should be FULLY logged in — stale marker must be cleaned up
+        $this->assertTrue($this->authenticator->loggedIn(), 'User should be logged in despite stale marker');
+        $this->assertFalse($this->authenticator->isPending(), 'User should NOT be pending');
+
+        // Stale marker must be deleted from DB
+        $this->dontSeeInDatabase($this->tables['identities'], [
+            'user_id' => $this->user->id,
+            'type'    => IdentityType::TOTP->value,
+        ]);
+    }
+
+    // -----------------------------------------------------------------------
+    // Login flow: user WITH TOTP, Totp2FA set as login action
+    // -----------------------------------------------------------------------
+
+    public function testLoginFlowWithTotpCreatesPendingState(): void
+    {
+        // Configure TOTP for the user
+        $this->user->enableTotp('TestApp');
+
+        // Enable Totp2FA action
+        /** @var Auth $config */
+        $config          = config('Auth');
+        $config->actions = ['login' => Totp2FA::class, 'register' => null];
+        Factories::injectMock('config', 'Auth', $config);
+
+        $result = $this->authenticator->attempt([
+            'email'    => $this->user->email,
+            'password' => 'secret123',
+        ]);
+
+        $this->assertTrue($result->isOK(), 'Attempt should succeed');
+
+        // User should be in PENDING state (TOTP code required)
+        $this->assertTrue($this->authenticator->isPending(), 'User should be in pending state');
+        $this->assertFalse($this->authenticator->loggedIn(), 'User should NOT be logged in yet');
+    }
+
+    // -----------------------------------------------------------------------
+    // Verify flow
+    // -----------------------------------------------------------------------
+
+    public function testCompleteTotpLoginFlowFromAttempt(): void
+    {
+        // Configure TOTP for the user
+        $this->user->enableTotp('TestApp');
+        $secret = $this->user->getTotpSecret();
+        $this->assertNotNull($secret);
+
+        // Enable Totp2FA action
+        /** @var Auth $config */
+        $config          = config('Auth');
+        $config->actions = ['login' => Totp2FA::class, 'register' => null];
+        Factories::injectMock('config', 'Auth', $config);
+
+        // Step 1: attempt login → should be pending
+        $result = $this->authenticator->attempt([
+            'email'    => $this->user->email,
+            'password' => 'secret123',
+        ]);
+
+        $this->assertTrue($result->isOK());
+        $this->assertTrue($this->authenticator->isPending());
+
+        // Step 2: simulate successful TOTP verification by replicating verify() logic
+        // (delete pending marker, remove session action keys, completeLogin)
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identityModel->deleteIdentitiesByType($this->user, IdentityType::TOTP->value);
+
+        // completeLogin() must clear auth_action from session and mark user as logged in
+        $this->authenticator->completeLogin($this->user);
+
+        // Step 3: verify state on a fresh authenticator instance (simulates next request)
+        $freshConfig = new Auth();
+        $freshAuth   = new Authentication($freshConfig);
+        $freshAuth->setProvider(model(UserModel::class));
+
+        /** @var Session $fresh */
+        $fresh = $freshAuth->factory('session');
+
+        $this->assertTrue($fresh->loggedIn(), 'Fresh instance should see user as logged in after TOTP verify');
+        $this->assertFalse($fresh->isPending(), 'Fresh instance should not see pending state');
+    }
+
+    public function testCompleteLoginClearsAuthActionFromSession(): void
+    {
+        // Set up pending session state manually
+        $_SESSION['user'] = [
+            'id'                  => $this->user->id,
+            'auth_action'         => Totp2FA::class,
+            'auth_action_message' => 'Enter your TOTP code.',
+        ];
+
+        // completeLogin() should clear auth_action so the next request sees LOGGED_IN
+        $this->authenticator->completeLogin($this->user);
+
+        // Session field should no longer contain auth_action
+        $sessionData = $_SESSION['user'];
+        $this->assertArrayNotHasKey('auth_action', $sessionData, 'auth_action must be removed from session by completeLogin()');
+        $this->assertArrayNotHasKey('auth_action_message', $sessionData, 'auth_action_message must be removed from session by completeLogin()');
+    }
+
+    public function testGetTypeReturnsTotp(): void
+    {
+        $action = new Totp2FA();
+        $this->assertSame('totp', $action->getType());
+    }
+}


### PR DESCRIPTION
Totp2FA no longer forces TOTP on users who haven't completed setup: createIdentity() now returns an empty string to skip the action for users without a confirmed TOTP, and returns 'totp' and inserts a pending marker for confirmed users. Stale pending markers are removed before inserting new ones. Session authenticator now clears auth_action/auth_action_message in completeLogin() and respects an empty secret from startUpAction() (treating the action as skipped). HasTotp() now only treats a confirmed identity (name='totp') as enabled, excluding unverified enrollment. UserSecurityController view calls were switched to use configurable view keys and a new security_overview view key was added to Auth config. Added comprehensive Totp2FATest unit tests and updated phpstan baseline to suppress a test-specific static method warning.