### PR TITLE
Add pending TOTP flow and local QR generation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "daycry/encryption": "^2.0",
         "daycry/jobs": "^1",
         "daycry/jwt": "^1.0",
+        "endroid/qr-code": "^6.0",
         "league/oauth2-facebook": "^2.0",
         "league/oauth2-github": "^3.0",
         "league/oauth2-google": "^4.0",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1161,7 +1161,7 @@ parameters:
 		-
 			rawMessage: 'Call to internal static method CodeIgniter\Config\Factories::injectMock() from outside its root namespace CodeIgniter.'
 			identifier: staticMethod.internal
-			count: 4
+			count: 5
 			path: tests/Authentication/Actions/Totp2FATest.php
 
 		-
@@ -1722,5 +1722,5 @@ parameters:
 		-
 			rawMessage: 'Call to internal static method CodeIgniter\Config\Factories::injectMock() from outside its root namespace CodeIgniter.'
 			identifier: staticMethod.internal
-			count: 5
+			count: 6
 			path: tests/_support/TestCase.php

--- a/src/Controllers/UserSecurityController.php
+++ b/src/Controllers/UserSecurityController.php
@@ -110,6 +110,9 @@ class UserSecurityController extends BaseAuthController
 
     /**
      * Show the TOTP setup page with QR code.
+     *
+     * Always generates a fresh secret. If the user navigates away before
+     * confirming, a new QR code will be issued on their next visit.
      */
     public function totpSetup(): RedirectResponse|string
     {
@@ -132,6 +135,9 @@ class UserSecurityController extends BaseAuthController
 
     /**
      * Confirm TOTP setup by verifying the first code.
+     *
+     * On failure the pending secret is kept so the user can retry with the same
+     * QR code already in their authenticator app.
      */
     public function totpSetupConfirm(): RedirectResponse|string
     {
@@ -139,12 +145,12 @@ class UserSecurityController extends BaseAuthController
         $code = (string) $this->request->getPost('token');
 
         if (! $user->verifyTotpCode($code)) {
-            // Remove the just-generated secret so setup can restart cleanly
-            $user->disableTotp();
-
             return redirect()->route('totp-setup')
                 ->with('error', lang('Auth.totpSetupInvalidCode'));
         }
+
+        // Mark the secret as confirmed — from this point hasTotpEnabled() returns true.
+        $user->confirmTotp();
 
         return $this->view(setting('Auth.views')['action_totp_setup_success'], [
             'redirectUrl' => url_to('security'),

--- a/src/Enums/TotpState.php
+++ b/src/Enums/TotpState.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Daycry\Auth\Enums;
+
+/**
+ * Represents the enrollment state stored in the `name` column of the
+ * `totp_secret` identity row.
+ *
+ * - PENDING  → secret generated but not yet confirmed by the user
+ * - CONFIRMED → first code verified; TOTP is fully active
+ */
+enum TotpState: string
+{
+    case PENDING   = 'totp_pending';
+    case CONFIRMED = 'totp';
+}

--- a/src/Libraries/TOTP.php
+++ b/src/Libraries/TOTP.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Daycry\Auth\Libraries;
 
+use Endroid\QrCode\QrCode;
+use Endroid\QrCode\Writer\PngWriter;
 use InvalidArgumentException;
 
 /**
@@ -105,15 +107,18 @@ class TOTP
     }
 
     /**
-     * Returns a Google Charts QR code image URL for the given otpauth URI.
-     * Useful for quickly rendering a QR code without a local library.
+     * Returns a base64 data URI (data:image/png;base64,...) containing the QR
+     * code for the given otpauth URI, generated locally via endroid/qr-code.
+     * The result can be used directly as the `src` of an `<img>` tag.
      */
     public static function getQRCodeUrl(string $otpAuthUrl, int $size = 200): string
     {
-        return 'https://chart.googleapis.com/chart?chs=' . $size . 'x' . $size
-            . '&chld=M|0'
-            . '&cht=qr'
-            . '&chl=' . rawurlencode($otpAuthUrl);
+        $qrCode = new QrCode($otpAuthUrl, size: $size);
+
+        $writer = new PngWriter();
+        $result = $writer->write($qrCode);
+
+        return $result->getDataUri();
     }
 
     /**

--- a/src/Traits/HasTotp.php
+++ b/src/Traits/HasTotp.php
@@ -15,6 +15,7 @@ namespace Daycry\Auth\Traits;
 
 use Daycry\Auth\Entities\UserIdentity;
 use Daycry\Auth\Enums\IdentityType;
+use Daycry\Auth\Enums\TotpState;
 use Daycry\Auth\Libraries\TOTP;
 use Daycry\Auth\Models\UserIdentityModel;
 
@@ -43,29 +44,56 @@ trait HasTotp
 
     /**
      * Returns true if the user has a confirmed TOTP 2FA secret.
-     * A secret stored during enrollment but not yet verified (name='totp_unverified')
+     * A secret stored during enrollment but not yet confirmed (name='totp_pending')
      * is NOT considered enabled.
      */
     public function hasTotpEnabled(): bool
     {
         $identity = $this->getTotpIdentity();
 
-        return $identity instanceof UserIdentity && $identity->name === 'totp';
+        return $identity instanceof UserIdentity && $identity->name === TotpState::CONFIRMED->value;
     }
 
     /**
-     * Returns the raw TOTP secret for the user, or null if TOTP is not configured.
+     * Returns true if a TOTP secret exists but has not yet been confirmed by the user.
+     * This happens when the setup QR has been shown but the first code not yet verified.
+     */
+    public function hasTotpPending(): bool
+    {
+        $identity = $this->getTotpIdentity();
+
+        return $identity instanceof UserIdentity && $identity->name === TotpState::PENDING->value;
+    }
+
+    /**
+     * Returns the decrypted TOTP secret for the user, or null if TOTP is not configured.
+     *
+     * The value stored in the database is AES-encrypted + base64-encoded.
+     * This method transparently decrypts and returns the original base32 secret.
      */
     public function getTotpSecret(): ?string
     {
         $identity = $this->getTotpIdentity();
 
-        return $identity instanceof UserIdentity ? $identity->secret : null;
+        if (! $identity instanceof UserIdentity || $identity->secret === null) {
+            return null;
+        }
+
+        $decoded = base64_decode((string) $identity->secret, true);
+
+        if ($decoded === false) {
+            return null;
+        }
+
+        return (string) service('encrypter')->decrypt($decoded);
     }
 
     /**
      * Generates a new TOTP secret, saves it for this user (or replaces the existing one),
      * and returns the otpauth:// URL for QR code generation.
+     *
+     * The secret is stored encrypted (symmetric AES) using CI4's Encryption service.
+     * Use getTotpSecret() to retrieve the decrypted value.
      *
      * @param string|null $issuer App name shown in the authenticator app.
      *                            Defaults to `Auth.totpIssuer` from the config file.
@@ -79,18 +107,35 @@ trait HasTotp
         // Remove any existing TOTP secret
         $model->deleteIdentitiesByType($this, IdentityType::TOTP_SECRET->value);
 
-        $secret = TOTP::generateSecret();
+        $secret          = TOTP::generateSecret();
+        $encryptedSecret = base64_encode(service('encrypter')->encrypt($secret));
 
         $model->insert([
             'user_id' => $this->id,
             'type'    => IdentityType::TOTP_SECRET->value,
-            'name'    => 'totp',
-            'secret'  => $secret,
+            'name'    => TotpState::PENDING->value,
+            'secret'  => $encryptedSecret,
         ]);
 
         $account = $this->email ?? $this->username ?? (string) $this->id;
 
         return TOTP::getOtpAuthUrl($secret, $account, $issuer);
+    }
+
+    /**
+     * Confirms a pending TOTP enrollment by marking the secret as verified.
+     * Must be called after the user successfully verifies the first code from
+     * the authenticator app. Before this call, hasTotpEnabled() returns false.
+     */
+    public function confirmTotp(): void
+    {
+        $model    = $this->totpIdentityModel();
+        $identity = $this->getTotpIdentity();
+
+        if ($identity instanceof UserIdentity && $identity->name === TotpState::PENDING->value) {
+            $identity->name = TotpState::CONFIRMED->value;
+            $model->save($identity);
+        }
     }
 
     /**

--- a/tests/Authentication/Actions/Totp2FATest.php
+++ b/tests/Authentication/Actions/Totp2FATest.php
@@ -21,7 +21,7 @@ use Daycry\Auth\Authentication\Authentication;
 use Daycry\Auth\Authentication\Authenticators\Session;
 use Daycry\Auth\Config\Auth;
 use Daycry\Auth\Enums\IdentityType;
-use Daycry\Auth\Libraries\TOTP;
+use Daycry\Auth\Enums\TotpState;
 use Daycry\Auth\Models\UserIdentityModel;
 use Daycry\Auth\Models\UserModel;
 use Tests\Support\DatabaseTestCase;
@@ -42,7 +42,6 @@ final class Totp2FATest extends DatabaseTestCase
 
         $this->setUpFakeUser();
 
-        // Set up the session authenticator
         $config = new Auth();
         $auth   = new Authentication($config);
         $auth->setProvider(model(UserModel::class));
@@ -54,14 +53,11 @@ final class Totp2FATest extends DatabaseTestCase
         $events = new MockEvents();
         Services::injectMock('events', $events);
 
-        // Set a known email on the user
         $this->user->email = 'foo@example.com';
         model(UserModel::class)->save($this->user);
 
-        // Truncate identities to avoid unique constraint conflicts
         $this->db->table($this->tables['identities'])->truncate();
 
-        // Create email identity for the user
         model(UserIdentityModel::class)->createEmailIdentity($this->user, [
             'email'    => 'foo@example.com',
             'password' => 'secret123',
@@ -69,7 +65,83 @@ final class Totp2FATest extends DatabaseTestCase
     }
 
     // -----------------------------------------------------------------------
-    // Unit: createIdentity()
+    // Two-phase enrollment: enableTotp() / hasTotpPending() / confirmTotp()
+    // -----------------------------------------------------------------------
+
+    public function testEnableTotpCreatesPendingSecret(): void
+    {
+        $this->user->enableTotp('TestApp');
+
+        $this->seeInDatabase($this->tables['identities'], [
+            'user_id' => $this->user->id,
+            'type'    => IdentityType::TOTP_SECRET->value,
+            'name'    => TotpState::PENDING->value,
+        ]);
+    }
+
+    public function testHasTotpEnabledFalseForPendingSecret(): void
+    {
+        $this->user->enableTotp('TestApp');
+
+        $this->assertFalse($this->user->hasTotpEnabled(), 'Pending secret must NOT be considered enabled');
+    }
+
+    public function testHasTotpPendingTrueAfterEnable(): void
+    {
+        $this->user->enableTotp('TestApp');
+
+        $this->assertTrue($this->user->hasTotpPending(), 'hasTotpPending() must return true after enableTotp()');
+    }
+
+    public function testHasTotpPendingFalseWhenNoSecret(): void
+    {
+        $this->assertFalse($this->user->hasTotpPending());
+    }
+
+    public function testConfirmTotpActivatesSecret(): void
+    {
+        $this->user->enableTotp('TestApp');
+        $this->assertFalse($this->user->hasTotpEnabled());
+
+        $this->user->confirmTotp();
+
+        $this->assertTrue($this->user->hasTotpEnabled(), 'hasTotpEnabled() must return true after confirmTotp()');
+        $this->assertFalse($this->user->hasTotpPending(), 'hasTotpPending() must return false after confirmTotp()');
+
+        $this->seeInDatabase($this->tables['identities'], [
+            'user_id' => $this->user->id,
+            'type'    => IdentityType::TOTP_SECRET->value,
+            'name'    => TotpState::CONFIRMED->value,
+        ]);
+    }
+
+    public function testConfirmTotpNoopWhenNoSecret(): void
+    {
+        // Should not throw when there is nothing to confirm
+        $this->user->confirmTotp();
+        $this->assertFalse($this->user->hasTotpEnabled());
+    }
+
+    public function testEnableTotpReplacesExistingPendingSecret(): void
+    {
+        $this->user->enableTotp('TestApp');
+        $secretFirst = $this->user->getTotpSecret();
+
+        $this->user->enableTotp('TestApp');
+        $secretSecond = $this->user->getTotpSecret();
+
+        // Only one totp_secret identity should exist
+        $count = $this->db->table($this->tables['identities'])
+            ->where('user_id', $this->user->id)
+            ->where('type', IdentityType::TOTP_SECRET->value)
+            ->countAllResults();
+
+        $this->assertSame(1, $count);
+        $this->assertNotSame($secretFirst, $secretSecond);
+    }
+
+    // -----------------------------------------------------------------------
+    // Unit: Totp2FA::createIdentity()
     // -----------------------------------------------------------------------
 
     public function testCreateIdentityReturnsEmptyForUserWithoutTotp(): void
@@ -77,23 +149,35 @@ final class Totp2FATest extends DatabaseTestCase
         $action = new Totp2FA();
         $result = $action->createIdentity($this->user);
 
-        $this->assertSame('', $result, 'createIdentity() must return empty string when user has no TOTP configured');
+        $this->assertSame('', $result, 'No TOTP at all → must skip action');
     }
 
-    public function testCreateIdentityReturnsTotpTypeForUserWithTotp(): void
+    public function testCreateIdentityReturnsEmptyForUserWithPendingTotp(): void
     {
-        // Configure TOTP for the user
+        // Pending setup (not yet confirmed) must NOT trigger the login action
         $this->user->enableTotp('TestApp');
 
         $action = new Totp2FA();
         $result = $action->createIdentity($this->user);
 
-        $this->assertSame('totp', $result, 'createIdentity() must return "totp" when user has TOTP configured');
+        $this->assertSame('', $result, 'Pending (unconfirmed) TOTP must not trigger the action');
     }
 
-    public function testCreateIdentityInsertsMarkerForUserWithTotp(): void
+    public function testCreateIdentityReturnsTotpTypeForUserWithConfirmedTotp(): void
     {
         $this->user->enableTotp('TestApp');
+        $this->user->confirmTotp();
+
+        $action = new Totp2FA();
+        $result = $action->createIdentity($this->user);
+
+        $this->assertSame('totp', $result, 'Confirmed TOTP must activate the login action');
+    }
+
+    public function testCreateIdentityInsertsLoginMarkerForConfirmedTotp(): void
+    {
+        $this->user->enableTotp('TestApp');
+        $this->user->confirmTotp();
 
         $action = new Totp2FA();
         $action->createIdentity($this->user);
@@ -116,9 +200,9 @@ final class Totp2FATest extends DatabaseTestCase
         ]);
     }
 
-    public function testCreateIdentityDeletesStaleMarker(): void
+    public function testCreateIdentityDeletesStaleLoginMarker(): void
     {
-        // Insert a stale marker manually
+        // Stale login marker with no confirmed TOTP secret
         model(UserIdentityModel::class)->insert([
             'user_id' => $this->user->id,
             'type'    => IdentityType::TOTP->value,
@@ -126,11 +210,9 @@ final class Totp2FATest extends DatabaseTestCase
             'secret'  => 'totp',
         ]);
 
-        // User has no TOTP secret configured
         $action = new Totp2FA();
         $action->createIdentity($this->user);
 
-        // Stale marker should be gone and no new one inserted
         $this->dontSeeInDatabase($this->tables['identities'], [
             'user_id' => $this->user->id,
             'type'    => IdentityType::TOTP->value,
@@ -138,39 +220,53 @@ final class Totp2FATest extends DatabaseTestCase
     }
 
     // -----------------------------------------------------------------------
-    // Login flow: user WITHOUT TOTP, Totp2FA set as login action
+    // Login flow: user WITHOUT confirmed TOTP
     // -----------------------------------------------------------------------
 
     public function testLoginFlowWithoutTotpCompletesLogin(): void
     {
-        // Enable Totp2FA action
         /** @var Auth $config */
         $config          = config('Auth');
         $config->actions = ['login' => Totp2FA::class, 'register' => null];
         Factories::injectMock('config', 'Auth', $config);
 
-        // Attempt login — user has NO TOTP configured
         $result = $this->authenticator->attempt([
             'email'    => $this->user->email,
             'password' => 'secret123',
         ]);
 
-        $this->assertTrue($result->isOK(), 'Attempt should succeed');
-
-        // User should be FULLY logged in (not pending)
-        $this->assertTrue($this->authenticator->loggedIn(), 'User should be logged in');
-        $this->assertFalse($this->authenticator->isPending(), 'User should NOT be in pending state');
+        $this->assertTrue($result->isOK());
+        $this->assertTrue($this->authenticator->loggedIn(), 'No TOTP → must complete login');
+        $this->assertFalse($this->authenticator->isPending());
     }
 
-    public function testLoginFlowWithoutTotpAndStaleMarkerCompletesLogin(): void
+    public function testLoginFlowWithPendingTotpCompletesLogin(): void
     {
-        // Enable Totp2FA action
+        // User started setup but never confirmed — must not be blocked at login
+        $this->user->enableTotp('TestApp');
+
         /** @var Auth $config */
         $config          = config('Auth');
         $config->actions = ['login' => Totp2FA::class, 'register' => null];
         Factories::injectMock('config', 'Auth', $config);
 
-        // Insert a stale totp pending marker (simulates abandoned previous login)
+        $result = $this->authenticator->attempt([
+            'email'    => $this->user->email,
+            'password' => 'secret123',
+        ]);
+
+        $this->assertTrue($result->isOK());
+        $this->assertTrue($this->authenticator->loggedIn(), 'Unconfirmed TOTP must not block login');
+        $this->assertFalse($this->authenticator->isPending());
+    }
+
+    public function testLoginFlowWithStaleMarkerCompletesLogin(): void
+    {
+        /** @var Auth $config */
+        $config          = config('Auth');
+        $config->actions = ['login' => Totp2FA::class, 'register' => null];
+        Factories::injectMock('config', 'Auth', $config);
+
         model(UserIdentityModel::class)->insert([
             'user_id' => $this->user->id,
             'type'    => IdentityType::TOTP->value,
@@ -179,19 +275,15 @@ final class Totp2FATest extends DatabaseTestCase
             'extra'   => 'You need to enter your TOTP code.',
         ]);
 
-        // Attempt login — user has NO TOTP configured, but stale DB marker exists
         $result = $this->authenticator->attempt([
             'email'    => $this->user->email,
             'password' => 'secret123',
         ]);
 
-        $this->assertTrue($result->isOK(), 'Attempt should succeed');
+        $this->assertTrue($result->isOK());
+        $this->assertTrue($this->authenticator->loggedIn(), 'Stale login marker must be cleaned up');
+        $this->assertFalse($this->authenticator->isPending());
 
-        // User should be FULLY logged in — stale marker must be cleaned up
-        $this->assertTrue($this->authenticator->loggedIn(), 'User should be logged in despite stale marker');
-        $this->assertFalse($this->authenticator->isPending(), 'User should NOT be pending');
-
-        // Stale marker must be deleted from DB
         $this->dontSeeInDatabase($this->tables['identities'], [
             'user_id' => $this->user->id,
             'type'    => IdentityType::TOTP->value,
@@ -199,15 +291,14 @@ final class Totp2FATest extends DatabaseTestCase
     }
 
     // -----------------------------------------------------------------------
-    // Login flow: user WITH TOTP, Totp2FA set as login action
+    // Login flow: user WITH confirmed TOTP
     // -----------------------------------------------------------------------
 
-    public function testLoginFlowWithTotpCreatesPendingState(): void
+    public function testLoginFlowWithConfirmedTotpCreatesPendingState(): void
     {
-        // Configure TOTP for the user
         $this->user->enableTotp('TestApp');
+        $this->user->confirmTotp();
 
-        // Enable Totp2FA action
         /** @var Auth $config */
         $config          = config('Auth');
         $config->actions = ['login' => Totp2FA::class, 'register' => null];
@@ -218,31 +309,25 @@ final class Totp2FATest extends DatabaseTestCase
             'password' => 'secret123',
         ]);
 
-        $this->assertTrue($result->isOK(), 'Attempt should succeed');
-
-        // User should be in PENDING state (TOTP code required)
-        $this->assertTrue($this->authenticator->isPending(), 'User should be in pending state');
-        $this->assertFalse($this->authenticator->loggedIn(), 'User should NOT be logged in yet');
+        $this->assertTrue($result->isOK());
+        $this->assertTrue($this->authenticator->isPending(), 'Confirmed TOTP must put user in pending state');
+        $this->assertFalse($this->authenticator->loggedIn());
     }
 
     // -----------------------------------------------------------------------
-    // Verify flow
+    // completeLogin() session cleanup
     // -----------------------------------------------------------------------
 
     public function testCompleteTotpLoginFlowFromAttempt(): void
     {
-        // Configure TOTP for the user
         $this->user->enableTotp('TestApp');
-        $secret = $this->user->getTotpSecret();
-        $this->assertNotNull($secret);
+        $this->user->confirmTotp();
 
-        // Enable Totp2FA action
         /** @var Auth $config */
         $config          = config('Auth');
         $config->actions = ['login' => Totp2FA::class, 'register' => null];
         Factories::injectMock('config', 'Auth', $config);
 
-        // Step 1: attempt login → should be pending
         $result = $this->authenticator->attempt([
             'email'    => $this->user->email,
             'password' => 'secret123',
@@ -251,16 +336,13 @@ final class Totp2FATest extends DatabaseTestCase
         $this->assertTrue($result->isOK());
         $this->assertTrue($this->authenticator->isPending());
 
-        // Step 2: simulate successful TOTP verification by replicating verify() logic
-        // (delete pending marker, remove session action keys, completeLogin)
         /** @var UserIdentityModel $identityModel */
         $identityModel = model(UserIdentityModel::class);
         $identityModel->deleteIdentitiesByType($this->user, IdentityType::TOTP->value);
 
-        // completeLogin() must clear auth_action from session and mark user as logged in
         $this->authenticator->completeLogin($this->user);
 
-        // Step 3: verify state on a fresh authenticator instance (simulates next request)
+        // Simulate next request with a fresh authenticator instance
         $freshConfig = new Auth();
         $freshAuth   = new Authentication($freshConfig);
         $freshAuth->setProvider(model(UserModel::class));
@@ -268,26 +350,23 @@ final class Totp2FATest extends DatabaseTestCase
         /** @var Session $fresh */
         $fresh = $freshAuth->factory('session');
 
-        $this->assertTrue($fresh->loggedIn(), 'Fresh instance should see user as logged in after TOTP verify');
-        $this->assertFalse($fresh->isPending(), 'Fresh instance should not see pending state');
+        $this->assertTrue($fresh->loggedIn(), 'Fresh instance must see user as logged in');
+        $this->assertFalse($fresh->isPending());
     }
 
     public function testCompleteLoginClearsAuthActionFromSession(): void
     {
-        // Set up pending session state manually
         $_SESSION['user'] = [
             'id'                  => $this->user->id,
             'auth_action'         => Totp2FA::class,
             'auth_action_message' => 'Enter your TOTP code.',
         ];
 
-        // completeLogin() should clear auth_action so the next request sees LOGGED_IN
         $this->authenticator->completeLogin($this->user);
 
-        // Session field should no longer contain auth_action
         $sessionData = $_SESSION['user'];
-        $this->assertArrayNotHasKey('auth_action', $sessionData, 'auth_action must be removed from session by completeLogin()');
-        $this->assertArrayNotHasKey('auth_action_message', $sessionData, 'auth_action_message must be removed from session by completeLogin()');
+        $this->assertArrayNotHasKey('auth_action', $sessionData);
+        $this->assertArrayNotHasKey('auth_action_message', $sessionData);
     }
 
     public function testGetTypeReturnsTotp(): void

--- a/tests/Authentication/Totp2FATest.php
+++ b/tests/Authentication/Totp2FATest.php
@@ -138,8 +138,15 @@ final class Totp2FATest extends DatabaseTestCase
         $otpAuthUrl = $this->user->enableTotp('TestApp');
 
         $this->assertStringStartsWith('otpauth://totp/', $otpAuthUrl);
-        $this->assertTrue($this->user->hasTotpEnabled());
+        // enableTotp() creates a PENDING secret — not yet confirmed
+        $this->assertTrue($this->user->hasTotpPending());
+        $this->assertFalse($this->user->hasTotpEnabled());
         $this->assertNotEmpty($this->user->getTotpSecret());
+
+        // After confirmation the secret becomes active
+        $this->user->confirmTotp();
+        $this->assertTrue($this->user->hasTotpEnabled());
+        $this->assertFalse($this->user->hasTotpPending());
     }
 
     public function testEnableTotpReplacesExistingSecret(): void
@@ -163,6 +170,7 @@ final class Totp2FATest extends DatabaseTestCase
     public function testDisableTotpRemovesSecret(): void
     {
         $this->user->enableTotp('TestApp');
+        $this->user->confirmTotp();
         $this->assertTrue($this->user->hasTotpEnabled());
 
         $this->user->disableTotp();

--- a/tests/_support/TestCase.php
+++ b/tests/_support/TestCase.php
@@ -17,6 +17,7 @@ use CodeIgniter\Config\Factories;
 use CodeIgniter\Settings\Config\Settings as SettingsConfig;
 use CodeIgniter\Settings\Settings;
 use CodeIgniter\Test\CIUnitTestCase;
+use Config\Encryption;
 use Config\Security;
 use Config\Services;
 use Daycry\Auth\Config\Auth;
@@ -59,6 +60,13 @@ abstract class TestCase extends CIUnitTestCase
         $config                 = config('Security');
         $config->csrfProtection = 'session';
         Factories::injectMock('config', 'Security', $config);
+
+        // Provide a fixed encryption key so service('encrypter') works in tests.
+        // The 64-char hex string gives a 32-byte key (AES-256).
+        /** @var Encryption $encConfig */
+        $encConfig      = config('Encryption');
+        $encConfig->key = hex2bin('0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef');
+        Factories::injectMock('config', 'Encryption', $encConfig);
     }
 
     protected function inkectMockAttributes(array $attributes = []): void


### PR DESCRIPTION
Introduce a two-phase TOTP enrollment (PENDING → CONFIRMED) via a new TotpState enum and confirmTotp() method. Store TOTP secrets encrypted (AES) and transparently decrypt in getTotpSecret(); enableTotp() now creates a pending secret. Replace Google Charts QR URLs with locally generated PNG data URIs using endroid/qr-code (added dependency). Update UserSecurityController comments/flow to keep pending secrets on verification failure and mark confirmed on success. Adjust tests and inject a fixed Encryption key for tests; update phpstan baseline counts accordingly.