### PR TITLE
Split config and update TOTP, identities, docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,9 +53,10 @@ composer ci
 
 - All PHP files must start with `declare(strict_types=1);`
 - All classes and methods must have DocBlocks with types
-- Code must pass PHPStan level 5 (`phpstan.neon.dist`). The baseline (`phpstan-baseline.neon`) suppresses ~592 known pre-existing errors from CI4 tooling. **Regenerate the baseline after fixing real errors** — never add suppressions manually.
+- Code must pass PHPStan level 5 (`phpstan.neon.dist`). The baseline (`phpstan-baseline.neon`) suppresses ~565 known pre-existing errors from CI4 tooling. **Regenerate the baseline after fixing real errors** — never add suppressions manually.
 - Namespace root: `Daycry\Auth`
 - `model(ClassName::class)` calls are flagged by the PHPStan CI4 plugin (they go to the baseline). Inside traits, centralize them in a private getter method rather than repeating them per method.
+- Use `setting('AuthSecurity.totpIssuer')` / `setting('Auth.views')` etc. (the `setting()` helper) rather than `config('Auth')->...` for settings that can be overridden at runtime.
 
 ## Architecture
 
@@ -64,8 +65,11 @@ composer ci
 ```
 src/
 ├── Auth.php                     # Main service facade (magic __call proxies to active authenticator)
-├── Config/Auth.php              # Central configuration (880+ lines, all features)
-├── Config/Registrar.php         # Auto-registers filters, validation rules, toolbar collector
+├── Config/
+│   ├── Auth.php                 # Core config: authenticators, views, tables, actions, routes
+│   ├── AuthSecurity.php         # Security config: passwords, lockout, rate-limit, TOTP, token lifetimes
+│   ├── AuthOAuth.php            # OAuth providers ($providers array)
+│   └── Registrar.php            # Auto-registers filters, validation rules, toolbar collector
 ├── Authentication/
 │   ├── Authenticators/
 │   │   ├── Base.php             # Abstract base: checkLogin(), forceLogin(), recordActiveDate()
@@ -82,8 +86,13 @@ src/
 │   ├── BaseAuthController.php   # Abstract: uses BaseControllerTrait + Viewable
 │   ├── Admin/                   # Bootstrap 5 admin panel (Users, Groups, Permissions, Logs, Dashboard)
 │   └── UserSecurityController.php  # User-facing TOTP + device session management
-├── Database/Migrations/         # 2023-12-07: core tables; 2026-02-26: indexes + device_sessions
+├── Database/Migrations/         # 2023-12-07: core tables; 2026-02-26: indexes + device_sessions;
+│                                #   2026-02-28: uuid columns + security columns (lockout, revoked_at)
 ├── Entities/                    # User (all traits), UserIdentity, AccessToken, DeviceSession, etc.
+├── Enums/
+│   ├── AuthenticationState.php  # UNKNOWN, PENDING, LOGGED_IN, LOGGED_OUT
+│   ├── IdentityType.php         # All identity type strings (EMAIL_PASSWORD, ACCESS_TOKEN, TOTP_SECRET…)
+│   └── TotpState.php            # PENDING = 'totp_pending', CONFIRMED = 'totp'
 ├── Filters/                     # AbstractAuthFilter + Group/Permission/Auth/Chain/Rates filters
 ├── Models/                      # UserModel, UserIdentityModel (central identity store), DeviceSessionModel, etc.
 ├── Services/                    # AttemptHandler, ExceptionHandler, RequestLogger
@@ -91,7 +100,7 @@ src/
 │   ├── Authorizable.php         # RBAC: groups/permissions with optional cache
 │   ├── HasAccessTokens.php      # Token CRUD (delegates to UserIdentityModel)
 │   ├── HasDeviceSessions.php    # Device session management
-│   ├── HasTotp.php              # TOTP enable/disable/verify
+│   ├── HasTotp.php              # TOTP enable/disable/verify (secret stored AES-encrypted)
 │   ├── Activatable.php          # Email activation flow
 │   ├── Bannable.php             # Ban/unban with reason
 │   ├── Resettable.php           # Password reset flow
@@ -115,28 +124,52 @@ Base (abstract)
 
 ### Identity model is the central identity store
 
-`UserIdentityModel` stores **all** identity types in a single `auth_users_identities` table:
-- `email_password` — hashed password
-- `access_token` — hashed Bearer tokens
-- `magic-link` — one-time login links
-- `email_2fa` — 6-digit email codes (ephemeral)
-- `email_activate` — activation codes
-- `totp_secret` — permanent TOTP secret (RFC 6238)
-- `totp` — ephemeral marker during TOTP login flow
+`UserIdentityModel` stores **all** identity types in a single `auth_users_identities` table. Use the `IdentityType` enum for all type strings:
+
+| `IdentityType` case | `secret` column contents |
+|---|---|
+| `EMAIL_PASSWORD` | email; `secret2` = bcrypt hash |
+| `ACCESS_TOKEN` | SHA-256 hash of raw token |
+| `JWT_REFRESH` | SHA-256 hash of raw token |
+| `TOTP_SECRET` | AES-encrypted + base64 secret (use `service('encrypter')`) |
+| `MAGIC_LINK`, `EMAIL_2FA`, `EMAIL_ACTIVATE`, `RESET_PASSWORD`, `EMAIL_CHANGE` | ephemeral codes |
+
+### TOTP two-phase enrollment
+
+`HasTotp` separates secret generation from confirmation via `TotpState`:
+
+1. `$user->enableTotp()` — generates a fresh AES-encrypted secret, stores it with `name = TotpState::PENDING`, returns the `otpauth://` URL. Calling it again replaces any existing secret (pending or confirmed).
+2. `$user->hasTotpPending()` / `$user->hasTotpEnabled()` — distinguish enrollment state.
+3. `$user->confirmTotp()` — updates `name` to `TotpState::CONFIRMED` after the user verifies their first code.
+4. `$user->getTotpSecret()` — transparently decrypts and returns the raw base32 secret.
+
+`Totp2FA` (login action) only fires when `hasTotpEnabled()` returns true (i.e. `CONFIRMED`). Users mid-enrollment (`PENDING`) are not challenged.
 
 ### Post-auth Action system
 
 After login/register, `Session` checks `Config\Auth::$actions['login']` and `$actions['register']`. If set, the user is redirected to `ActionController` before getting a session. Actions implement `ActionInterface`:
 - `Email2FA` — sends a 6-digit code and requires it
 - `EmailActivator` — requires email confirmation before allowing login
-- `Totp2FA` — validates a TOTP code; user must have `totp_secret` identity pre-configured via `$user->enableTotp()`
+- `Totp2FA` — validates a TOTP code; user must have confirmed TOTP (`hasTotpEnabled() === true`)
+
+`Session::completeLogin()` always clears `auth_action` / `auth_action_message` from the PHP session before setting `LOGGED_IN` state — this prevents stale pending-action state on subsequent requests.
+
+### Config split
+
+Configuration is split across three classes to keep concerns separate:
+
+| Class | Contains |
+|---|---|
+| `Config\Auth` | Authenticators, actions, views, table names, routes, session/remember-me settings |
+| `Config\AuthSecurity` | Passwords, lockout, rate-limit, TOTP issuer, token lifetimes, permission cache |
+| `Config\AuthOAuth` | OAuth provider definitions (`$providers` array) |
 
 ### Authorization (RBAC)
 
-The `Authorizable` trait (mixed into `User`) provides groups + permissions. Groups and their assigned permissions are stored in separate tables; both are loaded lazily and can be cached:
+The `Authorizable` trait (mixed into `User`) provides groups + permissions. Both are loaded lazily and can be cached:
 
 ```php
-// Config/Auth.php
+// Config/AuthSecurity.php
 $permissionCacheEnabled = false; // set true in production
 $permissionCacheTTL     = 300;   // seconds
 ```
@@ -160,11 +193,16 @@ Registered automatically via `Registrar.php`. Applied in CI4's `$routes` or filt
 
 ### Database schema
 
-Two migrations: `2023-12-07-000001_create_core_tables.php` (all core tables) and `2026-02-26-000001/000002` (performance indexes + `auth_device_sessions`). All table names are configurable via `$tables` in `Config/Auth.php`.
+- `2023-12-07-000001` — all core tables
+- `2026-02-26-000001/000002` — performance indexes + `auth_device_sessions`
+- `2026-02-28-000001` — `uuid` column on `users` and `device_sessions` (UUID v7, backfill included)
+- `2026-02-28-000002` — security columns: `failed_login_count`, `locked_until` on users; `revoked_at` on identities
+
+All table names are configurable via `$tables` in `Config/Auth.php`.
 
 ### OAuth2
 
-`OauthManager` uses League OAuth2 providers. Supported out of the box: `azure` (thenetworg/oauth2-azure), `google`, `facebook`, `github` (league/oauth2-*). Generic OIDC/OAuth via `GenericProvider`. Configured in `Config/Auth.php::$providers`.
+`OauthManager` uses League OAuth2 providers. Supported out of the box: `azure` (thenetworg/oauth2-azure), `google`, `facebook`, `github` (league/oauth2-*). Generic OIDC/OAuth via `GenericProvider`. Configured in `Config/AuthOAuth.php::$providers`.
 
 ### Device Sessions
 
@@ -173,12 +211,14 @@ When `$sessionConfig['trackDeviceSessions'] = true`, every `Session::startLogin(
 ### Testing
 
 Tests mirror the `src/` structure under `tests/`. Two base cases:
-- `Tests\Support\TestCase` — no DB, resets services, injects array settings handler
+- `Tests\Support\TestCase` — no DB, resets services, injects array settings handler + a fixed AES-256 encryption key so `service('encrypter')` works
 - `Tests\Support\DatabaseTestCase` — extends TestCase + `DatabaseTestTrait` (SQLite in-memory)
 
 **Inject mock config** in tests with:
 ```php
-$this->inkectMockAttributes(['defaultAuthenticator' => 'jwt']);
+$this->inkectMockAttributes(['defaultAuthenticator' => 'jwt']);          // Auth config
+$this->inkectMockAttributesSecurity(['userMaxAttempts' => 3]);            // AuthSecurity config
+$this->inkectMockAttributesOAuth(['providers' => [...]]);                 // AuthOAuth config
 ```
 
 **Slow-test detection** via Tachycardia (threshold: 0.50s). Coverage reports go to `build/coverage/`. Use `--no-coverage` flag during development.

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -2,24 +2,34 @@
 
 This guide covers every configuration option available in Daycry Auth.
 
-## The Configuration File
+## The Configuration Files
 
-After running `php spark auth:setup`, a file `app/Config/Auth.php` is created that extends the library's base configuration:
+Configuration is split across three files to keep concerns separate. After running `php spark auth:setup`, each is published to `app/Config/`:
+
+| File | Base class | Contains |
+|------|-----------|----------|
+| `app/Config/Auth.php` | `Daycry\Auth\Config\Auth` | Authenticators, actions, views, tables, routes, session/remember-me |
+| `app/Config/AuthSecurity.php` | `Daycry\Auth\Config\AuthSecurity` | Passwords, lockout, rate-limit, token lifetimes, TOTP issuer, permission cache |
+| `app/Config/AuthOAuth.php` | `Daycry\Auth\Config\AuthOAuth` | OAuth provider definitions |
+
+Override only what you need in each file:
 
 ```php
-<?php
-
+// app/Config/Auth.php
 namespace Config;
-
 use Daycry\Auth\Config\Auth as BaseAuth;
+class Auth extends BaseAuth { /* ... */ }
 
-class Auth extends BaseAuth
-{
-    // Override only what you need
-}
+// app/Config/AuthSecurity.php
+namespace Config;
+use Daycry\Auth\Config\AuthSecurity as BaseAuthSecurity;
+class AuthSecurity extends BaseAuthSecurity { /* ... */ }
+
+// app/Config/AuthOAuth.php
+namespace Config;
+use Daycry\Auth\Config\AuthOAuth as BaseAuthOAuth;
+class AuthOAuth extends BaseAuthOAuth { /* ... */ }
 ```
-
-All options listed below can be overridden in this file.
 
 ---
 
@@ -144,6 +154,8 @@ public array $validFields = [
 
 ## Password Settings
 
+> **File**: `app/Config/AuthSecurity.php`
+
 ```php
 // Minimum password length
 public int $minimumPasswordLength = 8;
@@ -176,6 +188,8 @@ public int $maxSimilarity = 50;
 
 ## Password Reset
 
+> **File**: `app/Config/AuthSecurity.php`
+
 ```php
 // How long a password reset token remains valid
 public int $passwordResetLifetime = HOUR; // Default: 1 hour
@@ -186,6 +200,8 @@ The reset flow is handled by `PasswordResetController`. Users request a reset li
 ---
 
 ## Per-User Account Lockout
+
+> **File**: `app/Config/AuthSecurity.php`
 
 Independent of IP-based blocking, this locks an individual account after too many failed password attempts:
 
@@ -203,6 +219,8 @@ When the lockout expires, the counter resets automatically on the next login att
 
 ## Magic Links
 
+> **File**: `app/Config/AuthSecurity.php`
+
 ```php
 public bool $allowMagicLinkLogins = true;
 public int  $magicLinkLifetime    = HOUR; // Token validity in seconds
@@ -211,6 +229,8 @@ public int  $magicLinkLifetime    = HOUR; // Token validity in seconds
 ---
 
 ## Access Tokens
+
+> **File**: `app/Config/AuthSecurity.php`
 
 ```php
 public bool $accessTokenEnabled = false;
@@ -232,6 +252,8 @@ public array $authenticatorHeader = [
 
 ## JWT Refresh Tokens
 
+> **File**: `app/Config/AuthSecurity.php`
+
 When using `JwtController` for stateless JWT authentication, refresh tokens allow issuing new access tokens without re-entering credentials:
 
 ```php
@@ -244,6 +266,8 @@ Refresh tokens are stored in `auth_users_identities` (type: `jwt_refresh`) and a
 ---
 
 ## Logging & Monitoring
+
+> **File**: `app/Config/AuthSecurity.php`
 
 ### Activity Logs
 
@@ -276,6 +300,8 @@ public int    $timeLimit     = MINUTE;  // Window size in seconds
 ---
 
 ## Authorization Cache
+
+> **File**: `app/Config/AuthSecurity.php`
 
 Avoid repeated database queries for group/permission checks in production:
 
@@ -459,23 +485,25 @@ public array $emailValidationRules = [
 
 ## OAuth Providers
 
+> **File**: `app/Config/AuthOAuth.php`
+
 ```php
 public array $providers = [
     'google' => [
-        'clientId'     => 'GOOGLE_CLIENT_ID',
-        'clientSecret' => 'GOOGLE_CLIENT_SECRET',
+        'clientId'     => env('OAUTH_GOOGLE_CLIENT_ID'),
+        'clientSecret' => env('OAUTH_GOOGLE_CLIENT_SECRET'),
         'redirectUri'  => 'https://yourapp.com/oauth/google/callback',
         'scopes'       => ['openid', 'email', 'profile'],
     ],
     'github' => [
-        'clientId'     => 'GITHUB_CLIENT_ID',
-        'clientSecret' => 'GITHUB_CLIENT_SECRET',
+        'clientId'     => env('OAUTH_GITHUB_CLIENT_ID'),
+        'clientSecret' => env('OAUTH_GITHUB_CLIENT_SECRET'),
         'redirectUri'  => 'https://yourapp.com/oauth/github/callback',
         'scopes'       => ['user:email'],
     ],
     'azure' => [
-        'clientId'     => 'AZURE_CLIENT_ID',
-        'clientSecret' => 'AZURE_CLIENT_SECRET',
+        'clientId'     => env('OAUTH_AZURE_CLIENT_ID'),
+        'clientSecret' => env('OAUTH_AZURE_CLIENT_SECRET'),
         'redirectUri'  => 'https://yourapp.com/oauth/azure/callback',
         'tenant'       => 'common',
         'scopes'       => ['openid', 'profile', 'email', 'offline_access'],
@@ -492,35 +520,44 @@ See [OAuth 2.0 & Social Login](09-oauth.md) for full setup instructions.
 ### Web Application
 
 ```php
-public bool   $allowRegistration = true;
+// app/Config/Auth.php
+public bool   $allowRegistration    = true;
 public string $defaultAuthenticator = 'session';
-public bool   $allowMagicLinkLogins = true;
-public int    $userMaxAttempts   = 5;
-public int    $userLockoutTime   = 1800; // 30 minutes
 public array  $actions = ['register' => null, 'login' => null];
+
+// app/Config/AuthSecurity.php
+public bool $allowMagicLinkLogins = true;
+public int  $userMaxAttempts      = 5;
+public int  $userLockoutTime      = 1800; // 30 minutes
 ```
 
 ### API (Stateless)
 
 ```php
+// app/Config/Auth.php
 public string $defaultAuthenticator = 'jwt';
-public bool   $accessTokenEnabled   = true;
-public int    $jwtRefreshLifetime   = 30 * DAY;
 public array  $authenticationChain  = ['jwt', 'access_token'];
-public int    $recordLoginAttempt   = 2;
+
+// app/Config/AuthSecurity.php
+public bool $accessTokenEnabled  = true;
+public int  $jwtRefreshLifetime  = 30 * DAY;
+public int  $recordLoginAttempt  = 2;
 ```
 
 ### High-Security
 
 ```php
-public int    $minimumPasswordLength = 12;
-public bool   $enableInvalidAttempts = true;
-public int    $maxAttempts           = 5;
-public int    $timeBlocked           = 3600;
-public int    $userMaxAttempts       = 3;
-public int    $userLockoutTime       = 7200;  // 2 hours
-public bool   $permissionCacheEnabled = true;
-public array  $actions = ['login' => \Daycry\Auth\Authentication\Actions\Totp2FA::class];
+// app/Config/Auth.php
+public array $actions = ['login' => \Daycry\Auth\Authentication\Actions\Totp2FA::class];
+
+// app/Config/AuthSecurity.php
+public int  $minimumPasswordLength  = 12;
+public bool $enableInvalidAttempts  = true;
+public int  $maxAttempts            = 5;
+public int  $timeBlocked            = 3600;
+public int  $userMaxAttempts        = 3;
+public int  $userLockoutTime        = 7200;  // 2 hours
+public bool $permissionCacheEnabled = true;
 ```
 
 ---

--- a/docs/08-testing.md
+++ b/docs/08-testing.md
@@ -36,23 +36,39 @@ composer test:coverage
 
 ### Test Environment Setup
 
+The library ships two ready-to-use base classes under `tests/_support/`:
+
+| Class | Use when |
+|-------|---------|
+| `Tests\Support\TestCase` | No database needed (unit tests, filter tests) |
+| `Tests\Support\DatabaseTestCase` | Tests that read/write the SQLite in-memory database |
+
+Both base classes automatically:
+- Reset all CI4 services between tests
+- Inject the array settings handler (so `setting()` calls work)
+- Inject a fixed AES-256 encryption key (so `service('encrypter')` works — needed for TOTP)
+- Seed with `CoreSeeder` (groups, permissions, one default user)
+
 ```php
 <?php
-// tests/_support/DatabaseTestCase.php
-namespace Tests\Support;
 
-use CodeIgniter\Test\CIUnitTestCase;
-use CodeIgniter\Test\DatabaseTestTrait;
+namespace Tests\Authentication;
 
-abstract class DatabaseTestCase extends CIUnitTestCase
+use Tests\Support\DatabaseTestCase;
+use Daycry\Auth\Entities\User;
+use Daycry\Auth\Models\UserModel;
+
+class MyAuthTest extends DatabaseTestCase
 {
-    use DatabaseTestTrait;
+    protected User $user;
 
-    protected $migrate = true;
-    protected $refresh = true;
-    protected $seed    = 'TestSeeder';
-    protected $basePath = 'tests/_support/Database/';
-    protected $namespace = 'Tests\Support';
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Create a test user via CI4 Fabricator
+        $this->user = fake(UserModel::class);
+    }
 }
 ```
 
@@ -86,60 +102,47 @@ abstract class DatabaseTestCase extends CIUnitTestCase
 namespace Tests\Authentication;
 
 use Tests\Support\DatabaseTestCase;
-use Daycry\Auth\Auth;
 use Daycry\Auth\Entities\User;
+use Daycry\Auth\Models\UserModel;
 
-class AuthenticationTestCase extends DatabaseTestCase
+class MySessionTest extends DatabaseTestCase
 {
-    protected Auth $auth;
     protected User $user;
 
     protected function setUp(): void
     {
         parent::setUp();
-        
-        $this->auth = service('auth');
-        
-        // Create test user
-        $this->user = new User([
-            'username' => 'testuser',
-            'email'    => 'test@example.com',
-            'password' => 'secret123'
-        ]);
-        $this->user->save();
+
+        // Use CI4 Fabricator to create a user with hashed password + email identity
+        $this->user = fake(UserModel::class);
     }
 
     protected function tearDown(): void
     {
         parent::tearDown();
-        
-        if ($this->auth->loggedIn()) {
-            $this->auth->logout();
-        }
+        auth('session')->logout();
     }
 }
 ```
 
 ### Mock Configuration
 
-```php
-<?php
-// For testing with different configurations
-class AuthTestCase extends DatabaseTestCase
-{
-    protected function createMockConfig(array $overrides = []): object
-    {
-        $config = (object) array_merge([
-            'enableInvalidAttempts' => true,
-            'maxAttempts'          => 5,
-            'timeToRemember'       => MONTH,
-            'loginRoute'           => '/login',
-        ], $overrides);
+Use the built-in helpers to override config properties for a single test:
 
-        return $config;
-    }
-}
+```php
+// Override Auth config (authenticators, actions, views, routes, session)
+$this->inkectMockAttributes(['defaultAuthenticator' => 'jwt']);
+$this->inkectMockAttributes(['actions' => ['login' => \Daycry\Auth\Authentication\Actions\Totp2FA::class]]);
+
+// Override AuthSecurity config (passwords, lockout, rate-limit, TOTP, token lifetimes)
+$this->inkectMockAttributesSecurity(['userMaxAttempts' => 3]);
+$this->inkectMockAttributesSecurity(['minimumPasswordLength' => 12]);
+
+// Override AuthOAuth config (provider definitions)
+$this->inkectMockAttributesOAuth(['providers' => ['google' => [...]]]);
 ```
+
+Each call replaces only the specified keys; unspecified keys keep their defaults.
 
 ## 🛡️ Testing Authentication
 

--- a/docs/09-oauth.md
+++ b/docs/09-oauth.md
@@ -63,16 +63,16 @@ composer require thenetworg/oauth2-azure  # Microsoft Azure
 
 ## Configuration
 
-Add your providers in `app/Config/Auth.php`:
+Add your providers in `app/Config/AuthOAuth.php`:
 
 ```php
 <?php
 
 namespace Config;
 
-use Daycry\Auth\Config\Auth as BaseAuth;
+use Daycry\Auth\Config\AuthOAuth as BaseAuthOAuth;
 
-class Auth extends BaseAuth
+class AuthOAuth extends BaseAuthOAuth
 {
     public array $providers = [
 

--- a/docs/10-totp-2fa.md
+++ b/docs/10-totp-2fa.md
@@ -8,10 +8,11 @@ Time-based One-Time Passwords (TOTP) add a powerful second layer of security to 
 - [Configuration](#configuration)
 - [User Enrollment](#user-enrollment)
 - [Login Flow](#login-flow)
-- [Managing TOTP in Controllers](#managing-totp-in-controllers)
-- [Disabling TOTP](#disabling-totp)
+- [HasTotp Trait Reference](#hastotp-trait-reference)
 - [UserSecurityController Integration](#usersecuritycontroller-integration)
+- [Disabling TOTP](#disabling-totp)
 - [Testing TOTP](#testing-totp)
+- [Security Notes](#security-notes)
 
 ---
 
@@ -22,7 +23,7 @@ User enters email + password
         ↓
 Credentials verified ✅
         ↓
-System detects TOTP action is required
+System detects Totp2FA action is required
         ↓
 User is shown a "Enter your 6-digit code" form
         ↓
@@ -33,7 +34,13 @@ Code verified against TOTP secret ✅
 Session created — user is logged in
 ```
 
-The TOTP secret is stored permanently in `auth_users_identities` with type `totp_secret`. Each login generates a temporary marker (`totp`) that is removed once verified.
+The TOTP secret is stored permanently in `auth_users_identities` with type `totp_secret`, **AES-256 encrypted** using CI4's `service('encrypter')`. The raw secret is never stored in plain text.
+
+Enrollment follows a two-phase flow:
+1. **Pending** (`name = totp_pending`) — secret generated, QR shown, user not yet confirmed
+2. **Confirmed** (`name = totp`) — first code verified, TOTP fully active
+
+The `Totp2FA` login action only challenges users whose TOTP is in the **confirmed** state.
 
 ---
 
@@ -41,7 +48,7 @@ The TOTP secret is stored permanently in `auth_users_identities` with type `totp
 
 ### 1. Enable the TOTP Post-Login Action
 
-In `app/Config/Auth.php`, set the `login` action to `Totp2FA`:
+In `app/Config/Auth.php`:
 
 ```php
 use Daycry\Auth\Authentication\Actions\Totp2FA;
@@ -52,141 +59,101 @@ public array $actions = [
 ];
 ```
 
-> **Note**: This only applies to users who have TOTP enabled. Users without a TOTP secret skip the 2FA step and log in directly.
+> **Note**: This only applies to users who have TOTP enabled (`hasTotpEnabled() === true`). Users who have not enrolled skip the 2FA step and log in directly.
 
-### 2. Verify Dependencies
+### 2. Set the Issuer Name
 
-The TOTP library is included automatically. No extra `composer require` needed.
+In `app/Config/AuthSecurity.php`, set the app name shown in the authenticator app:
+
+```php
+public string $totpIssuer = 'My App';
+```
+
+### 3. Configure the Encryption Key
+
+TOTP secrets are encrypted with CI4's encrypter. Make sure `app/Config/Encryption.php` has a key set (or `encryption.key` in `.env`):
+
+```bash
+# .env
+encryption.key = hex2bin:your64charhexstringhere
+```
 
 ---
 
 ## User Enrollment
 
-TOTP must be enabled per-user before they can use it. The typical flow is:
+The enrollment flow is handled by the `HasTotp` trait (mixed into `User`). It is a **two-phase** process:
 
-1. User navigates to their security settings
-2. They click "Enable Two-Factor Authentication"
-3. They scan a QR code with their authenticator app
-4. They enter a verification code to confirm the setup
-
-### Enable TOTP for a User
+### Phase 1 — Generate the QR code
 
 ```php
-<?php
+$user = auth()->user();
 
-namespace App\Controllers;
+// Always generates a fresh secret (replaces any previous pending one).
+// Returns the otpauth:// URI for building a QR code.
+$otpAuthUrl = $user->enableTotp('My App');
 
-use App\Controllers\BaseController;
-use Daycry\Auth\Libraries\TOTP;
+// getTotpSecret() transparently decrypts the stored value.
+$secret = $user->getTotpSecret();
 
-class SecurityController extends BaseController
-{
-    /**
-     * Step 1: Show the QR code for scanning.
-     */
-    public function enableTotpView()
-    {
-        $user = auth()->user();
+// Build a QR code data URI (rendered locally, no external service).
+$qrCodeDataUri = \Daycry\Auth\Libraries\TOTP::getQRCodeUrl($otpAuthUrl);
+// $qrCodeDataUri = "data:image/png;base64,..."
 
-        if ($user->hasTotpSecret()) {
-            return redirect()->to('security')->with('info', 'TOTP is already enabled.');
-        }
-
-        // Generate a new secret and store it temporarily in the session
-        $totp   = new TOTP();
-        $secret = $totp->generateSecret();
-
-        session()->set('totp_pending_secret', $secret);
-
-        // Build a QR code URL for the user's authenticator app
-        $qrCodeUrl = $totp->getQRCodeUrl(
-            issuer:   config('App')->appName,
-            account:  $user->email,
-            secret:   $secret
-        );
-
-        return view('security/totp_setup', [
-            'qrCodeUrl' => $qrCodeUrl,
-            'secret'    => $secret, // Show as plain text fallback
-        ]);
-    }
-
-    /**
-     * Step 2: Verify the first code — confirm the user scanned correctly.
-     */
-    public function enableTotpAction()
-    {
-        $user   = auth()->user();
-        $secret = session()->get('totp_pending_secret');
-        $code   = $this->request->getPost('code');
-
-        if ($secret === null) {
-            return redirect()->to('security/totp/enable')->with('error', 'Session expired. Please try again.');
-        }
-
-        $totp = new TOTP();
-
-        if (! $totp->verify($code, $secret)) {
-            return redirect()->back()->with('error', 'Invalid code. Please try again.');
-        }
-
-        // Code is valid — permanently enable TOTP for this user
-        $user->enableTotp($secret);
-
-        session()->remove('totp_pending_secret');
-
-        return redirect()->to('security')->with('message', 'Two-factor authentication is now enabled.');
-    }
-}
+return view('security/totp_setup', [
+    'qrCodeDataUri' => $qrCodeDataUri,
+    'secret'        => $secret, // plain-text fallback for manual entry
+]);
 ```
 
-### Example Setup View
+> `enableTotp()` stores the secret in the **pending** state. If the user navigates away before confirming, a fresh secret is generated the next time they visit the setup page.
+
+### Phase 2 — Confirm the first code
+
+```php
+$user = auth()->user();
+$code = $this->request->getPost('token');
+
+if (! $user->verifyTotpCode($code)) {
+    return redirect()->back()->with('error', 'Invalid code. Please try again.');
+}
+
+// Upgrades the secret from PENDING → CONFIRMED. TOTP is now active.
+$user->confirmTotp();
+
+return redirect()->to('security')->with('message', 'Two-factor authentication is now enabled.');
+```
+
+### Setup View
 
 ```html
-<!-- app/Views/security/totp_setup.php -->
-<div class="container mt-4">
-    <h2>Enable Two-Factor Authentication</h2>
+<!-- Phase 1: Show QR code -->
+<h2>Enable Two-Factor Authentication</h2>
 
-    <div class="card mb-4">
-        <div class="card-body">
-            <h5>Step 1: Scan this QR Code</h5>
-            <p>Open your authenticator app (Google Authenticator, Authy, etc.) and scan:</p>
+<h5>Step 1: Scan this QR Code</h5>
+<p>Open your authenticator app and scan:</p>
 
-            <!-- Use a QR code library, e.g. chillerlan/php-qrcode or an online API -->
-            <img src="https://api.qrserver.com/v1/create-qr-code/?data=<?= urlencode($qrCodeUrl) ?>&size=200x200"
-                 alt="QR Code">
+<!-- QR code is a data URI — no external service required -->
+<img src="<?= esc($qrCodeDataUri) ?>" alt="TOTP QR Code" width="200" height="200">
 
-            <p class="mt-2 text-muted">
-                Can't scan? Enter this code manually: <code><?= esc($secret) ?></code>
-            </p>
-        </div>
-    </div>
+<p class="text-muted mt-2">
+    Can't scan? Enter this code manually: <code><?= esc($secret) ?></code>
+</p>
 
-    <div class="card">
-        <div class="card-body">
-            <h5>Step 2: Enter the 6-digit code from your app</h5>
-            <?= form_open('security/totp/enable') ?>
-                <div class="mb-3">
-                    <input type="text"
-                           name="code"
-                           class="form-control"
-                           maxlength="6"
-                           placeholder="000000"
-                           autocomplete="one-time-code"
-                           required>
-                </div>
-                <button type="submit" class="btn btn-success">Confirm &amp; Enable</button>
-            <?= form_close() ?>
-        </div>
-    </div>
-</div>
+<!-- Phase 2: Confirm the code -->
+<h5>Step 2: Enter the 6-digit code from your app</h5>
+<?= form_open(url_to('totp-setup-confirm')) ?>
+    <input type="text" name="token" maxlength="6" placeholder="000000"
+           autocomplete="one-time-code" required>
+    <button type="submit">Confirm &amp; Enable</button>
+<?= form_close() ?>
 ```
 
 ---
 
 ## Login Flow
 
-Once TOTP is enabled for a user, the flow is handled **automatically** by the `Totp2FA` action. You do not need to modify your `LoginController`.
+Once TOTP is **confirmed** for a user, the flow is handled **automatically** by the `Totp2FA` action. No changes to `LoginController` are needed.
 
 ### What Happens Automatically
 
@@ -195,95 +162,71 @@ Once TOTP is enabled for a user, the flow is handled **automatically** by the `T
 3. Session detects the `Totp2FA` action is configured
 4. User is **redirected to the action show page** (not logged in yet)
 5. The built-in view asks for the 6-digit code
-6. `ActionController::verify()` validates the TOTP code
-7. On success, the session is created and the user is redirected
+6. `ActionController::verify()` decrypts the stored secret and validates the code
+7. On success, `completeLogin()` clears the pending action state and creates the session
 
-### Default TOTP Views
+### Override the Default TOTP Views
 
-The library provides default views. You can override them in `app/Config/Auth.php`:
+In `app/Config/Auth.php`:
 
 ```php
 public array $views = [
-    // ... other views
-    'action_totp_show'   => '\Daycry\Auth\Views\totp_show',
-    'action_totp_verify' => '\Daycry\Auth\Views\totp_verify',
+    // ... other views ...
+    'action_totp_setup_show'    => '\Daycry\Auth\Views\totp_setup_show',    // QR setup page
+    'action_totp_setup_success' => '\Daycry\Auth\Views\totp_setup_success', // Confirmation page
+    'action_totp_show'          => '\Daycry\Auth\Views\totp_show',          // Login 2FA prompt
+    'action_totp_verify'        => '\Daycry\Auth\Views\totp_verify',        // Login 2FA form
+    'security_overview'         => '\Daycry\Auth\Views\profile\security',   // User security dashboard
 ];
-```
-
-### Custom TOTP Verify View
-
-```html
-<!-- app/Views/auth/totp_verify.php -->
-<div class="container mt-5" style="max-width: 400px;">
-    <div class="card shadow-sm">
-        <div class="card-body">
-            <h4 class="card-title text-center">🔐 Two-Factor Authentication</h4>
-            <p class="text-muted text-center">Enter the 6-digit code from your authenticator app.</p>
-
-            <?php if (session('error')): ?>
-                <div class="alert alert-danger"><?= session('error') ?></div>
-            <?php endif ?>
-
-            <?= form_open(route_to('auth-action-verify')) ?>
-                <div class="mb-3">
-                    <input type="text"
-                           name="code"
-                           class="form-control form-control-lg text-center"
-                           maxlength="6"
-                           placeholder="000000"
-                           autocomplete="one-time-code"
-                           autofocus>
-                </div>
-                <button type="submit" class="btn btn-primary w-100">Verify</button>
-            <?= form_close() ?>
-        </div>
-    </div>
-</div>
 ```
 
 ---
 
-## Managing TOTP in Controllers
-
-### Check if a User Has TOTP Enabled
-
-```php
-$user = auth()->user();
-
-if ($user->hasTotpSecret()) {
-    echo "TOTP is enabled for this user.";
-} else {
-    echo "TOTP is not configured.";
-}
-```
-
-### The `HasTotp` Trait Methods
+## HasTotp Trait Reference
 
 The `User` entity uses the `HasTotp` trait, which provides:
 
 ```php
-// Check if TOTP secret exists
-$user->hasTotpSecret(): bool
+// === Enrollment ===
 
-// Enable TOTP with a given secret (call after verifying the first code)
-$user->enableTotp(string $secret): void
+// Generate a new secret (pending), returns the otpauth:// URL.
+// If called again, replaces any existing secret.
+$user->enableTotp(?string $issuer = null): string
 
-// Disable TOTP (removes the stored secret)
+// Returns true while the secret is generated but not yet confirmed.
+$user->hasTotpPending(): bool
+
+// Returns true only after confirmTotp() has been called.
+$user->hasTotpEnabled(): bool
+
+// Upgrades the identity from PENDING to CONFIRMED.
+// Call only after verifyTotpCode() returns true.
+$user->confirmTotp(): void
+
+// Returns the decrypted base32 secret (or null if not set).
+$user->getTotpSecret(): ?string
+
+// === Verification ===
+
+// Checks a 6-digit code against the user's stored secret.
+$user->verifyTotpCode(string $code): bool
+
+// === Removal ===
+
+// Removes the TOTP secret identity entirely (both pending and confirmed).
 $user->disableTotp(): void
-
-// Verify a given 6-digit code against the user's secret
-$user->verifyTotp(string $code): bool
 ```
 
-### Example: Security Dashboard
+### Security Dashboard Example
 
 ```php
-public function securityIndex()
+public function securityIndex(): string
 {
     $user = auth()->user();
 
     return view('security/index', [
-        'totpEnabled'  => $user->hasTotpSecret(),
+        'totpEnabled'  => $user->hasTotpEnabled(),
+        'totpPending'  => $user->hasTotpPending(),
         'deviceCount'  => count($user->getDeviceSessions()),
     ]);
 }
@@ -291,16 +234,37 @@ public function securityIndex()
 
 ---
 
-## Disabling TOTP
+## UserSecurityController Integration
+
+Daycry Auth ships with `UserSecurityController` which provides ready-to-use TOTP management endpoints. Register the routes in `app/Config/Routes.php`:
 
 ```php
-public function disableTotpAction()
+$routes->group('security', ['filter' => 'session', 'namespace' => 'Daycry\Auth\Controllers'], static function ($routes) {
+    $routes->get('/',             'UserSecurityController::index',          ['as' => 'security']);
+    $routes->get('totp/setup',    'UserSecurityController::totpSetup',      ['as' => 'totp-setup']);
+    $routes->post('totp/confirm', 'UserSecurityController::totpSetupConfirm', ['as' => 'totp-setup-confirm']);
+    $routes->post('totp/disable', 'UserSecurityController::totpDisable',    ['as' => 'totp-disable']);
+
+    // Device session management
+    $routes->post('sessions/(:num)/revoke', 'UserSecurityController::revokeSession/$1', ['as' => 'revoke-session']);
+    $routes->post('sessions/revoke-all',    'UserSecurityController::revokeAllSessions', ['as' => 'revoke-all-sessions']);
+});
+```
+
+The views are configured in `app/Config/Auth.php` under the `$views` array (see [Override the Default TOTP Views](#override-the-default-totp-views) above).
+
+---
+
+## Disabling TOTP
+
+Always require password confirmation before disabling 2FA:
+
+```php
+public function disableTotpAction(): RedirectResponse
 {
     $user     = auth()->user();
     $password = $this->request->getPost('current_password');
 
-    // Always require password confirmation before disabling 2FA
-    /** @var \Daycry\Auth\Authentication\Passwords $passwords */
     $passwords = service('passwords');
 
     if (! $passwords->verify($password, $user->getPasswordHash())) {
@@ -315,22 +279,9 @@ public function disableTotpAction()
 
 ---
 
-## UserSecurityController Integration
-
-Daycry Auth ships with `UserSecurityController` that provides ready-to-use TOTP management endpoints. Add the routes in `app/Config/Routes.php`:
-
-```php
-$routes->group('security', ['filter' => 'session', 'namespace' => 'Daycry\Auth\Controllers'], static function ($routes) {
-    // TOTP management
-    $routes->get('totp/enable',  'UserSecurityController::totpEnableView',   ['as' => 'totp-enable']);
-    $routes->post('totp/enable', 'UserSecurityController::totpEnableAction');
-    $routes->post('totp/disable','UserSecurityController::totpDisableAction', ['as' => 'totp-disable']);
-});
-```
-
----
-
 ## Testing TOTP
+
+`DatabaseTestCase` automatically injects a 32-byte AES encryption key, so `service('encrypter')` works without any extra setup in your tests.
 
 ```php
 <?php
@@ -342,57 +293,73 @@ use Daycry\Auth\Libraries\TOTP;
 
 class TotpTest extends DatabaseTestCase
 {
-    public function testEnableAndVerifyTotp(): void
+    public function testEnrollAndVerifyTotp(): void
     {
-        $user = $this->createUser();
+        $user = fake(UserModel::class);
 
-        $totp   = new TOTP();
-        $secret = $totp->generateSecret();
+        // Phase 1: generate secret (creates a PENDING identity)
+        $otpAuthUrl = $user->enableTotp('TestApp');
 
-        // Simulate enrollment
-        $user->enableTotp($secret);
+        $this->assertStringStartsWith('otpauth://totp/', $otpAuthUrl);
+        $this->assertTrue($user->hasTotpPending());
+        $this->assertFalse($user->hasTotpEnabled());
+        $this->assertNotEmpty($user->getTotpSecret());
 
-        $this->assertTrue($user->hasTotpSecret());
+        // Phase 2: confirm — TOTP becomes active
+        $user->confirmTotp();
+
+        $this->assertTrue($user->hasTotpEnabled());
+        $this->assertFalse($user->hasTotpPending());
     }
 
-    public function testVerifyInvalidCodeFails(): void
+    public function testVerifyTotpCode(): void
     {
-        $user = $this->createUser();
+        $user = fake(UserModel::class);
+        $user->enableTotp('TestApp');
+        $user->confirmTotp();
 
-        $totp   = new TOTP();
-        $secret = $totp->generateSecret();
-        $user->enableTotp($secret);
-
-        // An obviously wrong code
-        $this->assertFalse($user->verifyTotp('000000'));
+        // An obviously wrong code should fail
+        $this->assertFalse($user->verifyTotpCode('000000'));
     }
 
     public function testDisableTotpRemovesSecret(): void
     {
-        $user = $this->createUser();
-
-        $totp   = new TOTP();
-        $secret = $totp->generateSecret();
-        $user->enableTotp($secret);
+        $user = fake(UserModel::class);
+        $user->enableTotp('TestApp');
+        $user->confirmTotp();
         $user->disableTotp();
 
-        $this->assertFalse($user->hasTotpSecret());
+        $this->assertFalse($user->hasTotpEnabled());
+        $this->assertNull($user->getTotpSecret());
+    }
+
+    public function testSecretIsEncryptedInDatabase(): void
+    {
+        $user = fake(UserModel::class);
+        $user->enableTotp('TestApp');
+
+        /** @var \Daycry\Auth\Models\UserIdentityModel $model */
+        $model    = model(\Daycry\Auth\Models\UserIdentityModel::class);
+        $identity = $model->where('user_id', $user->id)
+                          ->where('type', 'totp_secret')
+                          ->first();
+
+        // The DB value is base64-encoded ciphertext — not the raw secret
+        $this->assertNotSame($user->getTotpSecret(), $identity->secret);
+        $this->assertNotEmpty(base64_decode($identity->secret, true));
     }
 }
 ```
 
 ---
 
-## Security Tips
-
-```{admonition} Best Practices
-:class: tip
+## Security Notes
 
 - **Always require password confirmation** before enabling or disabling TOTP.
-- Explain to users that **losing access to their authenticator app** could lock them out — consider implementing backup codes.
-- TOTP codes are valid for a 30-second window (with a configurable clock skew tolerance). Ensure your server clock is synchronized (NTP).
-- The TOTP secret is stored in the `auth_users_identities` table. Make sure your database access is properly secured.
-```
+- The TOTP secret is stored **AES-256 encrypted** in `auth_users_identities`. The raw base32 secret is never in the database in plain text.
+- TOTP codes are valid for a **30-second window** (±1 window tolerance for clock skew). Ensure your server clock is synchronized via NTP.
+- If a user loses access to their authenticator app they will be locked out. Consider implementing **backup codes** (not included) or an admin unlock procedure.
+- A user with a **pending** (unconfirmed) TOTP secret is **not** challenged at login. If they navigate away before confirming, they simply aren't enrolled yet.
 
 ---
 


### PR DESCRIPTION
Split configuration into three classes (Config\Auth, Config\AuthSecurity, Config\AuthOAuth) and update docs to reflect the new files and where settings belong. Document identity types and introduce IdentityType/TotpState/AuthenticationState enums; clarify UserIdentityModel storage formats (AES-encrypted TOTP secrets, hashed tokens, ephemeral codes). Describe a two-phase TOTP enrollment (PENDING -> CONFIRMED), ensure secrets are AES-256 encrypted via service('encrypter'), and note that Totp2FA only challenges confirmed TOTP. Add migration notes (uuid and security columns), update OAuth provider config to use env vars, and move provider config to AuthOAuth. Improve testing docs: DatabaseTestCase injects a fixed encrypter key and seeds core data; add helpers to mock Auth/AuthSecurity/AuthOAuth attributes. Update examples, views, routes, and tests to reflect API changes (enableTotp/confirmTotp/getTotpSecret/verifyTotpCode, QR data URI, updated view names). Minor doc cleanups and wording updates throughout CLAUDE.md and docs/*.md.