### PR TITLE
v5.0.0

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3']
+        php-versions: ['8.2', '8.3', '8.4', '8.5']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -20,7 +20,7 @@ jobs:
         php-versions: ['8.2', '8.3', '8.4', '8.5']
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -34,7 +34,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-php-${{ matrix.php-versions }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -52,7 +52,7 @@ jobs:
     needs: tests
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup PHP with Xdebug
         uses: shivammathur/setup-php@v2
@@ -66,7 +66,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-php-8.3-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -27,14 +27,14 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-php-8.3-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-php-8.3-composer-
 
       - name: Cache PHPStan results
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: build/phpstan
           key: ${{ runner.os }}-phpstan-${{ hashFiles('src/**/*.php', 'tests/**/*.php') }}
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -68,7 +68,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-php-8.3-composer-${{ hashFiles('**/composer.lock') }}
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -99,7 +99,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{ steps.composercache.outputs.dir }}
           key: ${{ runner.os }}-php-8.3-composer-${{ hashFiles('**/composer.lock') }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-    "php.version": "8.3"
+    "php.version": "8.5"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.0.0] - 2026-03-20
+
+### Added
+
+#### OAuth Profile System
+- **`IdentityType::oauthProvider()` static helper** — centralises the `oauth_` prefix convention for dynamic provider types. Replaces all manual `'oauth_' . $provider` string concatenation across the codebase.
+- **`OAuthTokenRepository`** (`src/Models/OAuthTokenRepository.php`) — dedicated repository for OAuth identity CRUD, following the same pattern as `AccessTokenRepository` and `JwtTokenRepository`. Methods:
+  - `findByUserAndProvider(int $userId, string $provider)` — find OAuth identity for a user/provider pair
+  - `findByProviderAndSocialId(string $provider, string $socialId)` — find by provider type and social ID
+  - `createOAuthIdentity(int $userId, string $provider, array $data)` — insert a new OAuth identity
+  - `updateOAuthIdentity(UserIdentity $identity)` — update an existing identity (token refresh, re-login)
+  - `getProfileData(int $userId, string $provider)` — get stored profile data from the `extra` JSON
+  - `parseExtra(?string $extra)` — parse `extra` column with backward compatibility (JSON and legacy plain-string format)
+- **Config-based `ProfileResolverFactory`** — the factory now accepts `$providerConfig` and resolves profile resolvers in this order:
+  1. `$providerConfig['profileResolver']` — custom class (must implement `ProfileResolverInterface`, throws `LogicException` otherwise)
+  2. Built-in map (`azure` -> `AzureProfileResolver`)
+  3. Fallback -> `GenericProfileResolver`
+- **`profileResolver` config key** — documented in `AuthOAuth.php` Generic provider example; allows per-provider custom resolver classes
+- **`scopes_granted` in extra JSON** — when the OAuth provider returns granted scopes in the token response (RFC 6749 SS3.3), they are stored as an array in the identity's `extra` JSON. Updated on both initial login and token refresh.
+- **`profile_fetched_at` in extra JSON** — ISO 8601 timestamp recorded when profile fields are fetched, allowing consumers to know the freshness of cached profile data
+
+#### OAuth Events
+- **`oauth-login`** — fired after every successful OAuth login via `handleCallback()`. Arguments: `User $user`, `string $providerName`
+- **`oauth-profile-fetched`** — fired when profile fields were resolved (only when `fields` is configured and data was returned). Arguments: `User $user`, `string $providerName`, `array $profileData`
+
+#### Tests
+- `tests/Models/OAuthTokenRepositoryTest.php` — 10 tests covering find, create, update, getProfileData, parseExtra (JSON, legacy, empty)
+- `tests/Libraries/Oauth/ProfileResolver/ProfileResolverFactoryTest.php` — 4 tests: Azure resolver, generic fallback, config-based override, invalid resolver throws
+- `tests/Libraries/OauthManagerTest.php` — 9 new tests:
+  - `testRefreshAccessTokenWithJsonExtra` / `testRefreshAccessTokenWithLegacyExtra` — refresh with JSON and legacy extra formats
+  - `testRefreshAccessTokenNoIdentity` / `testRefreshAccessTokenProviderFails` — null return cases
+  - `testHandleCallbackTriggersOauthLoginEvent` / `testHandleCallbackTriggersProfileFetchedEvent` — event verification
+  - `testHandleCallbackStoresScopesGranted` — scopes extracted from token response
+  - `testHandleCallbackStoresProfileFetchedAt` — timestamp presence in extra JSON
+
+#### Documentation
+- `docs/09-oauth.md` — complete rewrite with 11 new sections: Architecture, Stored Token Data (JSON structure), Profile Fields (configuring, resolvers, custom resolver, reading data), Scopes Granted, OAuth Events, OAuthTokenRepository reference, IdentityType Helper, Testing OAuth
+- `docs/02-configuration.md` — updated OAuth section with `fields`, `fieldsEndpoint`, `profileResolver` keys; added Provider Configuration Keys reference table
+- `docs/07-logging.md` — added `oauth-login` and `oauth-profile-fetched` to the events table; added OAuth Login Tracking section
+- `docs/08-testing.md` — added OAuth test file references
+- `docs/README.md` — added OAuth Profile Fields & Resolvers, OAuth Events, OAuthTokenRepository to Feature Matrix
+- `docs/index.md` — updated OAuth description
+- `CLAUDE.md` — added `OAuthTokenRepository` to source layout and token repositories table; expanded OAuth2 section
+
+### Changed
+
+- **`OauthManager` refactored** — all identity CRUD delegated to `OAuthTokenRepository` via lazy-initialised `getRepository()` getter. Centralised `getIdentityModel()` replaces three separate `model(UserIdentityModel::class)` calls. Removed private `parseExtra()` method (now public on repository).
+- **`ProfileResolverFactory::create()` signature** — now accepts optional `array $providerConfig = []` as second parameter for config-based resolver resolution
+- **`OauthManager::processUser()`** — login event (`auth()->login()`) no longer triggers events itself; `oauth-login` and `oauth-profile-fetched` are fired from `handleCallback()` after `processUser()` returns
+- **`OauthManager::refreshAccessToken()`** — now updates `scopes_granted` in extra JSON when the refreshed token includes scope information
+- PHPStan baseline regenerated: 599 -> 627 suppressions (new repository, tests, Mockery patterns)
+
 ## [4.0.0] - 2026-03-01
 
 ### Breaking Changes
@@ -172,6 +224,7 @@ class AuthOAuth extends AuthOAuthConfig
 - `UserProviderInterface` missing `update()` method — caused PHPStan errors in `Session` authenticator per-user lockout code
 - `ForcePasswordResetController::getValidationRules()` incorrect PHPDoc return type
 
-[Unreleased]: https://github.com/daycry/auth/compare/v4.0.0...HEAD
+[Unreleased]: https://github.com/daycry/auth/compare/v5.0.0...HEAD
+[5.0.0]: https://github.com/daycry/auth/compare/v4.0.0...v5.0.0
 [4.0.0]: https://github.com/daycry/auth/compare/v3.1.0...v4.0.0
 [3.1.0]: https://github.com/daycry/auth/compare/v3.0.6...v3.1.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,10 +53,11 @@ composer ci
 
 - All PHP files must start with `declare(strict_types=1);`
 - All classes and methods must have DocBlocks with types
-- Code must pass PHPStan level 5 (`phpstan.neon.dist`). The baseline (`phpstan-baseline.neon`) suppresses ~565 known pre-existing errors from CI4 tooling. **Regenerate the baseline after fixing real errors** — never add suppressions manually.
+- Code must pass PHPStan level 5 (`phpstan.neon.dist`). The baseline (`phpstan-baseline.neon`) suppresses ~573 known pre-existing errors from CI4 tooling. **Regenerate the baseline after fixing real errors** — never add suppressions manually.
 - Namespace root: `Daycry\Auth`
 - `model(ClassName::class)` calls are flagged by the PHPStan CI4 plugin (they go to the baseline). Inside traits, centralize them in a private getter method rather than repeating them per method.
 - Use `setting('AuthSecurity.totpIssuer')` / `setting('Auth.views')` etc. (the `setting()` helper) rather than `config('Auth')->...` for settings that can be overridden at runtime.
+- Notable `AuthSecurity` properties: `$rememberMePurgeChance` (int, default 20) — probability of remember-me token purge; `$pwnedPasswordsApiUrl` (string) — configurable HaveIBeenPwned API URL.
 
 ## Architecture
 
@@ -74,11 +75,20 @@ src/
 │   ├── Authenticators/
 │   │   ├── Base.php             # Abstract base: checkLogin(), forceLogin(), recordActiveDate()
 │   │   ├── StatelessAuthenticator.php  # Abstract: login/logout/loggedIn/loginById for stateless auth
-│   │   ├── Session.php          # Stateful: $_SESSION + remember-me + device sessions
+│   │   ├── Session.php          # Stateful: orchestrates services (see delegation pattern below)
 │   │   ├── AccessToken.php      # Stateless: X-API-KEY header or query param
 │   │   ├── JWT.php              # Stateless: Authorization: Bearer <token>
 │   │   └── Guest.php            # Anonymous fallback
-│   ├── Actions/                 # Post-auth hooks: Email2FA, EmailActivator, Totp2FA
+│   ├── Actions/
+│   │   ├── AbstractAction.php      # Base: requirePendingUser(), getIdentity(), getIdentityModel()
+│   │   ├── Email2FA.php            # Extends AbstractAction
+│   │   ├── EmailActivator.php      # Extends AbstractAction
+│   │   └── Totp2FA.php             # Extends AbstractAction
+│   ├── Services/
+│   │   ├── DeviceSessionRecorder.php   # recordSession(), terminateCurrentSession()
+│   │   ├── PendingActionCoordinator.php # findPendingAction(), activateAction()
+│   │   ├── RememberMe.php              # Remember-me token lifecycle
+│   │   └── UserLockoutManager.php      # isLockedOut(), recordFailedAttempt(), resetOnSuccess()
 │   ├── JWT/Adapters/            # DaycryJWTAdapter (wraps daycry/jwt)
 │   └── Passwords/               # CompositionValidator, NothingPersonalValidator, DictionaryValidator
 ├── Authorization/Groups.php     # Group utilities
@@ -91,14 +101,24 @@ src/
 ├── Entities/                    # User (all traits), UserIdentity, AccessToken, DeviceSession, etc.
 ├── Enums/
 │   ├── AuthenticationState.php  # UNKNOWN, PENDING, LOGGED_IN, LOGGED_OUT
-│   ├── IdentityType.php         # All identity type strings (EMAIL_PASSWORD, ACCESS_TOKEN, TOTP_SECRET…)
+│   ├── IdentityType.php         # All identity type strings + oauthProvider() dynamic helper
 │   └── TotpState.php            # PENDING = 'totp_pending', CONFIRMED = 'totp'
 ├── Filters/                     # AbstractAuthFilter + Group/Permission/Auth/Chain/Rates filters
-├── Models/                      # UserModel, UserIdentityModel (central identity store), DeviceSessionModel, etc.
+├── Models/
+│   ├── UserModel.php               # User CRUD + UUID generation
+│   ├── UserIdentityModel.php       # Central identity store (base queries)
+│   ├── AccessTokenRepository.php   # Access token CRUD (wraps UserIdentityModel)
+│   ├── JwtTokenRepository.php      # JWT refresh token CRUD (wraps UserIdentityModel)
+│   ├── OAuthTokenRepository.php    # OAuth identity CRUD (wraps UserIdentityModel)
+│   ├── DeviceSessionModel.php      # Device session CRUD + UUID generation
+│   └── ...                         # GroupModel, PermissionModel, LoginModel, etc.
+├── Libraries/
+│   ├── TOTP.php                    # TOTP secret/QR generation + verification
+│   └── TokenEmailSender.php        # Token generation + email sending (used by MagicLink, PasswordReset)
 ├── Services/                    # AttemptHandler, ExceptionHandler, RequestLogger
 ├── Traits/
 │   ├── Authorizable.php         # RBAC: groups/permissions with optional cache
-│   ├── HasAccessTokens.php      # Token CRUD (delegates to UserIdentityModel)
+│   ├── HasAccessTokens.php      # Token CRUD (delegates to AccessTokenRepository)
 │   ├── HasDeviceSessions.php    # Device session management
 │   ├── HasTotp.php              # TOTP enable/disable/verify (secret stored AES-encrypted)
 │   ├── Activatable.php          # Email activation flow
@@ -122,6 +142,19 @@ Base (abstract)
 
 **Critical**: `loggedIn()` on stateless authenticators re-validates the token on **every call** (no in-memory cache between calls). Calling `auth()->loggedIn()` twice in a request hits the DB/JWT check twice.
 
+### Session delegates to focused services
+
+`Session.php` orchestrates four extracted service classes instead of implementing all logic inline:
+
+| Service | Responsibility |
+|---------|---------------|
+| `UserLockoutManager` | Per-user lockout: `isLockedOut()`, `recordFailedAttempt()`, `resetOnSuccess()` |
+| `DeviceSessionRecorder` | Device session tracking: `recordSession()`, `terminateCurrentSession()` |
+| `PendingActionCoordinator` | Post-auth actions: `findPendingAction()`, `activateAction()` |
+| `RememberMe` | Remember-me token lifecycle |
+
+All services are injected or instantiated in Session's constructor and read config via `setting()`.
+
 ### Identity model is the central identity store
 
 `UserIdentityModel` stores **all** identity types in a single `auth_users_identities` table. Use the `IdentityType` enum for all type strings:
@@ -133,6 +166,18 @@ Base (abstract)
 | `JWT_REFRESH` | SHA-256 hash of raw token |
 | `TOTP_SECRET` | AES-encrypted + base64 secret (use `service('encrypter')`) |
 | `MAGIC_LINK`, `EMAIL_2FA`, `EMAIL_ACTIVATE`, `RESET_PASSWORD`, `EMAIL_CHANGE` | ephemeral codes |
+
+### Token repositories
+
+Token-specific CRUD is encapsulated in focused repository classes that wrap `UserIdentityModel`:
+
+| Repository | Delegates from | Key methods |
+|-----------|---------------|-------------|
+| `AccessTokenRepository` | `HasAccessTokens` trait, `AccessToken` authenticator | `generateAccessToken()`, `softRevokeAccessToken()`, `getAccessTokenByRawToken()` |
+| `JwtTokenRepository` | `JwtController` | `createRefreshToken()`, `getRefreshToken()`, `softRevokeRefreshToken()` |
+| `OAuthTokenRepository` | `OauthManager` | `findByUserAndProvider()`, `findByProviderAndSocialId()`, `createOAuthIdentity()`, `updateOAuthIdentity()`, `getProfileData()`, `parseExtra()` |
+
+Both AccessToken and JWT use soft-revocation (`revoked_at` column) by default. The old hard-delete methods on `UserIdentityModel` are `@deprecated`.
 
 ### TOTP two-phase enrollment
 
@@ -151,6 +196,13 @@ After login/register, `Session` checks `Config\Auth::$actions['login']` and `$ac
 - `Email2FA` — sends a 6-digit code and requires it
 - `EmailActivator` — requires email confirmation before allowing login
 - `Totp2FA` — validates a TOTP code; user must have confirmed TOTP (`hasTotpEnabled() === true`)
+
+All three action classes extend `AbstractAction`, which provides shared helpers:
+- `requirePendingUser()` — returns the pending-login user from the session authenticator
+- `getIdentity(User $user)` — returns the identity for this action's type
+- `getIdentityModel()` — returns the `UserIdentityModel` instance
+
+Adding a new action: extend `AbstractAction`, implement `ActionInterface`, set `$type` to the `IdentityType` string.
 
 `Session::completeLogin()` always clears `auth_action` / `auth_action_message` from the PHP session before setting `LOGGED_IN` state — this prevents stale pending-action state on subsequent requests.
 
@@ -203,6 +255,29 @@ All table names are configurable via `$tables` in `Config/Auth.php`.
 ### OAuth2
 
 `OauthManager` uses League OAuth2 providers. Supported out of the box: `azure` (thenetworg/oauth2-azure), `google`, `facebook`, `github` (league/oauth2-*). Generic OIDC/OAuth via `GenericProvider`. Configured in `Config/AuthOAuth.php::$providers`.
+
+OAuth identity types are dynamic (`oauth_google`, `oauth_github`, etc.) — use `IdentityType::oauthProvider($name)` instead of string concatenation.
+
+`OauthManager` delegates all identity CRUD to `OAuthTokenRepository` (lazy-initialised via `getRepository()`). The centralized `getIdentityModel()` avoids repeated `model()` calls.
+
+**Profile system**: When `$providerConfig['fields']` is configured, `OauthManager` fetches extra profile data via `ProfileResolverFactory`. The factory supports three resolver strategies:
+1. `$providerConfig['profileResolver']` — custom class (must implement `ProfileResolverInterface`)
+2. Built-in map (`azure` → `AzureProfileResolver`)
+3. Fallback → `GenericProfileResolver`
+
+Profile data and metadata are stored in the identity's `extra` JSON column:
+```json
+{
+  "refresh_token": "...",
+  "scopes_granted": ["openid", "profile", "email"],
+  "profile": {"department": "Engineering"},
+  "profile_fetched_at": "2026-03-20 12:00:00"
+}
+```
+
+**OAuth events** (fired by `handleCallback()`):
+- `oauth-login` — after successful login: `Events::trigger('oauth-login', $user, $providerName)`
+- `oauth-profile-fetched` — when profile fields were resolved: `Events::trigger('oauth-profile-fetched', $user, $providerName, $profileData)`
 
 ### Device Sessions
 

--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,15 @@
     "license": "MIT",
     "require": {
         "php": "^8.1",
-        "codeigniter4/settings": "*",
+        "codeigniter4/settings": "^2",
         "daycry/class-finder": "^2.0",
         "daycry/encryption": "^2.0",
         "daycry/jobs": "^1",
-        "daycry/jwt": "^1.0",
+        "daycry/jwt": "^2.0",
         "endroid/qr-code": "^6.0",
         "league/oauth2-facebook": "^2.0",
         "league/oauth2-github": "^3.0",
         "league/oauth2-google": "^4.0",
-        "michalsn/codeigniter4-uuid": "dev-develop",
         "thenetworg/oauth2-azure": "^2"
     },
     "require-dev":

--- a/docs/02-configuration.md
+++ b/docs/02-configuration.md
@@ -506,12 +506,33 @@ public array $providers = [
         'clientSecret' => env('OAUTH_AZURE_CLIENT_SECRET'),
         'redirectUri'  => 'https://yourapp.com/oauth/azure/callback',
         'tenant'       => 'common',
-        'scopes'       => ['openid', 'profile', 'email', 'offline_access'],
+        'scopes'       => ['openid', 'profile', 'email', 'offline_access', 'User.Read'],
+        'fields'       => ['department', 'jobTitle'],  // Extra profile data from Graph API
     ],
+    // Generic provider with custom profile resolver:
+    // 'my_provider' => [
+    //     'clientId'        => env('MY_PROVIDER_CLIENT_ID'),
+    //     'clientSecret'    => env('MY_PROVIDER_CLIENT_SECRET'),
+    //     'redirectUri'     => 'https://yourapp.com/oauth/my_provider/callback',
+    //     'fields'          => ['role', 'team'],
+    //     'fieldsEndpoint'  => 'https://api.example.com/userinfo',
+    //     'profileResolver' => \App\OAuth\MyCustomResolver::class,
+    // ],
 ];
 ```
 
-See [OAuth 2.0 & Social Login](09-oauth.md) for full setup instructions.
+### Provider Configuration Keys
+
+| Key | Description |
+|-----|-------------|
+| `clientId`, `clientSecret`, `redirectUri` | Standard OAuth credentials (required) |
+| `scopes` | OAuth scopes to request |
+| `fields` | Extra profile fields to fetch after login |
+| `fieldsEndpoint` | Custom API URL for profile fields (GenericProfileResolver) |
+| `profileResolver` | Custom resolver class (must implement `ProfileResolverInterface`) |
+| `tenant` | Azure-only: `'common'`, `'organizations'`, or tenant GUID |
+
+See [OAuth 2.0 & Social Login](09-oauth.md) for full setup instructions, profile resolvers, OAuth events, and the `OAuthTokenRepository`.
 
 ---
 

--- a/docs/07-logging.md
+++ b/docs/07-logging.md
@@ -63,7 +63,7 @@ Events::on('registered', static function (object $user): void {
 
 ## Available Events
 
-| Event | When Fired | Argument |
+| Event | When Fired | Arguments |
 |-------|-----------|----------|
 | `pre-login` | Before credentials are checked | `array $credentials` |
 | `login` | After successful login | `User $user` |
@@ -73,6 +73,8 @@ Events::on('registered', static function (object $user): void {
 | `registered` | After successful registration | `User $user` |
 | `passwordReset` | After password successfully reset | `User $user` |
 | `magicLogin` | After magic link login | `User $user` |
+| `oauth-login` | After successful OAuth login | `User $user`, `string $providerName` |
+| `oauth-profile-fetched` | After profile fields resolved from OAuth provider | `User $user`, `string $providerName`, `array $profileData` |
 
 ---
 
@@ -126,6 +128,22 @@ Events::on('passwordReset', static function (object $user): void {
     ]);
 });
 ```
+
+### OAuth Login Tracking
+
+```php
+// Log all OAuth logins with provider name
+Events::on('oauth-login', static function (object $user, string $provider): void {
+    log_message('info', "OAuth login via {$provider} for user {$user->email}");
+});
+
+// Sync profile data when fetched from OAuth provider
+Events::on('oauth-profile-fetched', static function (object $user, string $provider, array $profileData): void {
+    log_message('info', "Profile fetched from {$provider}: " . json_encode(array_keys($profileData)));
+});
+```
+
+See [OAuth 2.0 & Social Login](09-oauth.md#oauth-events) for more details on OAuth events.
 
 ---
 

--- a/docs/08-testing.md
+++ b/docs/08-testing.md
@@ -572,10 +572,12 @@ composer test -- --display-deprecations
 For more test examples, check the `/tests` directory:
 
 - `tests/Authentication/` - Authentication tests
-- `tests/Authorization/` - Authorization tests  
+- `tests/Authorization/` - Authorization tests
 - `tests/Controllers/` - Controller tests
 - `tests/Entities/` - Entity tests
-- `tests/Models/` - Model tests
+- `tests/Models/` - Model tests (including `OAuthTokenRepositoryTest`)
+- `tests/Libraries/OauthManagerTest.php` - OAuth manager tests (events, scopes, profile, refresh)
+- `tests/Libraries/Oauth/ProfileResolver/` - Profile resolver tests (factory, Azure, generic)
 
 ## 🔗 Related Documentation
 

--- a/docs/09-oauth.md
+++ b/docs/09-oauth.md
@@ -1,10 +1,11 @@
-# 🌐 OAuth 2.0 & Social Login
+# OAuth 2.0 & Social Login
 
 Daycry Auth integrates with [PHP League's OAuth2 Client](https://oauth2-client.leagueofphp.com/) to support social login via external providers. Users can authenticate with **Google**, **GitHub**, **Facebook**, **Microsoft/Azure**, or any standard OAuth2/OIDC provider.
 
-## 📋 Table of Contents
+## Table of Contents
 
 - [How It Works](#how-it-works)
+- [Architecture](#architecture)
 - [Installation](#installation)
 - [Configuration](#configuration)
 - [Routing](#routing)
@@ -15,9 +16,20 @@ Daycry Auth integrates with [PHP League's OAuth2 Client](https://oauth2-client.l
   - [Facebook](#facebook)
   - [Microsoft / Azure](#microsoft--azure)
   - [Generic OIDC Provider](#generic-oidc-provider)
+- [Stored Token Data](#stored-token-data)
+- [Profile Fields](#profile-fields)
+  - [Configuring Profile Fields](#configuring-profile-fields)
+  - [Profile Resolvers](#profile-resolvers)
+  - [Custom Profile Resolver](#custom-profile-resolver)
+  - [Reading Stored Profile Data](#reading-stored-profile-data)
+- [Scopes Granted](#scopes-granted)
 - [Refresh Tokens](#refresh-tokens)
+- [OAuth Events](#oauth-events)
+- [OAuthTokenRepository](#oauthtokenrepository)
+- [IdentityType Helper](#identitytype-helper)
 - [Unlinking a Provider](#unlinking-a-provider)
 - [Account Linking Strategy](#account-linking-strategy)
+- [Testing OAuth](#testing-oauth)
 
 ---
 
@@ -25,20 +37,39 @@ Daycry Auth integrates with [PHP League's OAuth2 Client](https://oauth2-client.l
 
 ```
 User clicks "Login with Google"
-        ↓
+        |
 Redirected to Google OAuth consent screen
-        ↓
-User authorizes → Google redirects back to /oauth/google/callback
-        ↓
+        |
+User authorizes -> Google redirects back to /oauth/google/callback
+        |
 System retrieves the user's email from Google
-        ↓
-If email exists → link the OAuth identity and log in
-If email is new → create user account, link identity, log in
-        ↓
-Tokens stored in auth_users_identities for later API calls
+        |
+If email exists -> link the OAuth identity and log in
+If email is new -> create user account, link identity, log in
+        |
+Tokens + profile data stored in auth_users_identities
+        |
+Events fired: oauth-login (always), oauth-profile-fetched (if fields configured)
 ```
 
 The OAuth identity is stored in `auth_users_identities` with type `oauth_{provider}` (e.g., `oauth_google`, `oauth_github`). One user can have multiple OAuth providers linked.
+
+---
+
+## Architecture
+
+The OAuth subsystem is composed of several focused classes:
+
+| Class | Responsibility |
+|-------|---------------|
+| `OauthManager` | Orchestrates the OAuth flow: redirect, callback, token refresh |
+| `OAuthTokenRepository` | All OAuth identity CRUD (find, create, update, parse extra) |
+| `ProfileResolverFactory` | Creates the appropriate profile resolver for a provider |
+| `AzureProfileResolver` | Azure-specific: uses Microsoft Graph API for profile fields |
+| `GenericProfileResolver` | Default: extracts fields from `toArray()` or a custom endpoint |
+| `IdentityType::oauthProvider()` | Builds the `oauth_{name}` type string (replaces manual concatenation) |
+
+`OauthManager` delegates all identity persistence to `OAuthTokenRepository`, following the same pattern as `AccessTokenRepository` and `JwtTokenRepository`.
 
 ---
 
@@ -110,6 +141,21 @@ class AuthOAuth extends BaseAuthOAuth
 }
 ```
 
+### Provider Configuration Keys
+
+Each provider entry supports these keys:
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `clientId` | Yes | OAuth client ID |
+| `clientSecret` | Yes | OAuth client secret |
+| `redirectUri` | Yes | Callback URL for the provider |
+| `scopes` | No | OAuth scopes to request |
+| `fields` | No | Extra profile fields to fetch (see [Profile Fields](#profile-fields)) |
+| `fieldsEndpoint` | No | Custom API endpoint for profile fields |
+| `profileResolver` | No | Custom profile resolver class (see [Custom Profile Resolver](#custom-profile-resolver)) |
+| `tenant` | Azure only | Azure AD tenant: `'common'`, `'organizations'`, or a tenant GUID |
+
 > **Security**: Always load credentials from environment variables, never hardcode them.
 
 ---
@@ -177,8 +223,8 @@ composer require league/oauth2-google
 
 **Google Cloud Console setup**:
 1. Go to [console.cloud.google.com](https://console.cloud.google.com)
-2. Create a project → Enable "Google+ API" or "People API"
-3. Credentials → Create OAuth 2.0 Client ID (Web application)
+2. Create a project -> Enable "Google+ API" or "People API"
+3. Credentials -> Create OAuth 2.0 Client ID (Web application)
 4. Add `https://yourapp.com/oauth/google/callback` to Authorized redirect URIs
 
 ```php
@@ -200,7 +246,7 @@ composer require league/oauth2-github
 ```
 
 **GitHub setup**:
-1. GitHub → Settings → Developer Settings → OAuth Apps → New OAuth App
+1. GitHub -> Settings -> Developer Settings -> OAuth Apps -> New OAuth App
 2. Set Homepage URL and Authorization callback URL
 
 ```php
@@ -222,7 +268,7 @@ composer require league/oauth2-facebook
 
 **Facebook setup**:
 1. Go to [developers.facebook.com](https://developers.facebook.com)
-2. Create App → Add "Facebook Login" product
+2. Create App -> Add "Facebook Login" product
 3. Set Valid OAuth Redirect URIs
 
 ```php
@@ -244,8 +290,8 @@ composer require thenetworg/oauth2-azure
 ```
 
 **Azure setup**:
-1. Go to [portal.azure.com](https://portal.azure.com) → Azure Active Directory → App registrations
-2. New registration → set Redirect URI to your callback URL
+1. Go to [portal.azure.com](https://portal.azure.com) -> Azure Active Directory -> App registrations
+2. New registration -> set Redirect URI to your callback URL
 3. Add a client secret under Certificates & secrets
 
 ```php
@@ -257,7 +303,9 @@ composer require thenetworg/oauth2-azure
     // 'organizations' = work accounts only
     // '{tenant-guid}' = specific tenant only
     'tenant'  => 'common',
-    'scopes'  => ['openid', 'profile', 'email', 'offline_access'],
+    'scopes'  => ['openid', 'profile', 'email', 'offline_access', 'User.Read'],
+    // Optional: fetch extra fields from Microsoft Graph
+    'fields'  => ['department', 'jobTitle', 'officeLocation', 'mobilePhone'],
 ],
 ```
 
@@ -278,8 +326,186 @@ For providers that follow OpenID Connect standards:
     'urlAccessToken'          => 'https://idp.example.com/token',
     'urlResourceOwnerDetails' => 'https://idp.example.com/userinfo',
     'scopes'                  => ['openid', 'email', 'profile'],
+    'fields'                  => ['role', 'team'],
+    'fieldsEndpoint'          => 'https://api.example.com/userinfo',
+    // 'profileResolver'      => \App\OAuth\MyCustomResolver::class,
 ],
 ```
+
+---
+
+## Stored Token Data
+
+After authentication, the following is stored in `auth_users_identities`:
+
+| Column | Contains |
+|--------|---------|
+| `type` | `oauth_{provider}` (e.g., `oauth_google`) |
+| `secret` | Provider's social user ID |
+| `secret2` | Access token |
+| `extra` | JSON object (see below) |
+| `expires` | Access token expiry timestamp |
+
+### Extra JSON Structure
+
+The `extra` column stores a JSON object with the following fields:
+
+```json
+{
+    "refresh_token": "rt_abc123...",
+    "scopes_granted": ["openid", "profile", "email"],
+    "profile": {
+        "department": "Engineering",
+        "jobTitle": "Senior Developer"
+    },
+    "profile_fetched_at": "2026-03-20 14:30:00"
+}
+```
+
+| Field | Present when | Description |
+|-------|-------------|-------------|
+| `refresh_token` | Provider issues one | OAuth refresh token for offline access |
+| `scopes_granted` | Token includes `scope` value | Array of scopes the provider actually granted (RFC 6749 SS3.3) |
+| `profile` | `fields` is configured | Extra profile data from the provider |
+| `profile_fetched_at` | `profile` is present | Timestamp when the profile data was last fetched |
+
+**Backward compatibility**: Legacy identities that stored the refresh token as a plain string (not JSON) in `extra` are handled transparently. `OAuthTokenRepository::parseExtra()` detects the format and normalises it.
+
+---
+
+## Profile Fields
+
+Daycry Auth can fetch additional profile data from the provider beyond the standard email and name. This is useful for syncing organisational attributes like department, job title, or custom claims.
+
+### Configuring Profile Fields
+
+Add a `fields` array to any provider configuration:
+
+```php
+'azure' => [
+    'clientId'     => env('OAUTH_AZURE_CLIENT_ID'),
+    'clientSecret' => env('OAUTH_AZURE_CLIENT_SECRET'),
+    'redirectUri'  => 'https://yourapp.com/oauth/azure/callback',
+    'tenant'       => 'your-tenant-guid',
+    'scopes'       => ['openid', 'profile', 'email', 'offline_access', 'User.Read'],
+    // Fetch these fields from Microsoft Graph on login
+    'fields'       => ['department', 'jobTitle', 'officeLocation', 'mobilePhone'],
+],
+```
+
+When `fields` is set, `OauthManager` calls the appropriate profile resolver after the OAuth callback. The resolved data is stored in the `extra` JSON under the `profile` key, along with a `profile_fetched_at` timestamp.
+
+If the profile fetch fails (network error, permission denied, etc.), login still succeeds — the error is logged as a warning.
+
+### Profile Resolvers
+
+Profile resolvers extract field data from the provider. The `ProfileResolverFactory` chooses the resolver in this order:
+
+1. **Config-based**: If `$providerConfig['profileResolver']` is set, that class is used (must implement `ProfileResolverInterface`)
+2. **Built-in map**: `azure` -> `AzureProfileResolver`
+3. **Fallback**: `GenericProfileResolver`
+
+#### AzureProfileResolver
+
+For Azure, the resolver calls the Microsoft Graph API (`https://graph.microsoft.com/v1.0/me`) to fetch the requested fields. Requires the `User.Read` scope.
+
+#### GenericProfileResolver
+
+The generic resolver works for any provider. It tries two strategies in order:
+
+1. **Custom endpoint**: If `fieldsEndpoint` is configured, it fetches data from that URL using the access token and filters the response to only the requested fields.
+2. **Resource owner data**: If no endpoint is configured (or it fails), it uses `$resourceOwner->toArray()` and filters the fields.
+
+### Custom Profile Resolver
+
+To implement a custom resolver for a specific provider:
+
+```php
+<?php
+
+namespace App\OAuth;
+
+use Daycry\Auth\Libraries\Oauth\ProfileResolver\ProfileResolverInterface;
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use League\OAuth2\Client\Token\AccessTokenInterface;
+
+class MyCustomResolver implements ProfileResolverInterface
+{
+    public function fetchFields(
+        AbstractProvider $provider,
+        AccessTokenInterface $token,
+        ResourceOwnerInterface $resourceOwner,
+        array $fields,
+        array $config = [],
+    ): array {
+        // Custom logic to fetch profile fields
+        $request  = $provider->getAuthenticatedRequest('GET', 'https://api.myprovider.com/user/profile', $token);
+        $response = $provider->getParsedResponse($request);
+
+        if (! is_array($response)) {
+            return [];
+        }
+
+        // Return only the requested fields
+        return array_intersect_key($response, array_flip($fields));
+    }
+}
+```
+
+Register it in the provider config:
+
+```php
+'my_provider' => [
+    'clientId'        => env('MY_PROVIDER_CLIENT_ID'),
+    'clientSecret'    => env('MY_PROVIDER_CLIENT_SECRET'),
+    'redirectUri'     => 'https://yourapp.com/oauth/my_provider/callback',
+    'fields'          => ['role', 'team', 'avatar_url'],
+    'profileResolver' => \App\OAuth\MyCustomResolver::class,
+],
+```
+
+If the class does not implement `ProfileResolverInterface`, a `LogicException` is thrown at runtime.
+
+### Reading Stored Profile Data
+
+```php
+use Daycry\Auth\Libraries\Oauth\OauthManager;
+
+$user    = auth()->user();
+$manager = new OauthManager(config('AuthOAuth'));
+$manager->setProvider('azure');
+
+$profile = $manager->getProfileData($user);
+// Returns: ['department' => 'Engineering', 'jobTitle' => 'Senior Dev', ...]
+
+// Or use the repository directly:
+use Daycry\Auth\Models\OAuthTokenRepository;
+use Daycry\Auth\Models\UserIdentityModel;
+
+$repo    = new OAuthTokenRepository(model(UserIdentityModel::class));
+$profile = $repo->getProfileData((int) $user->id, 'azure');
+```
+
+---
+
+## Scopes Granted
+
+When the OAuth provider returns the granted scopes in the token response (as per RFC 6749 SS3.3), Daycry Auth stores them in the `extra` JSON as `scopes_granted`:
+
+```php
+// After login, check what scopes were actually granted
+$repo     = new OAuthTokenRepository(model(UserIdentityModel::class));
+$identity = $repo->findByUserAndProvider((int) $user->id, 'azure');
+$extra    = $repo->parseExtra($identity->extra);
+
+$scopes = $extra['scopes_granted'] ?? [];
+// ['openid', 'profile', 'email', 'User.Read']
+```
+
+This is useful when the provider may grant fewer scopes than requested (e.g., the user declined a specific permission).
+
+Scopes are also updated when a token is refreshed via `refreshAccessToken()`.
 
 ---
 
@@ -287,25 +513,13 @@ For providers that follow OpenID Connect standards:
 
 Some providers (Azure with `offline_access`, Google with `access_type=offline`) issue refresh tokens that let you make API calls on behalf of users without requiring them to re-authenticate.
 
-### Stored Token Data
-
-After authentication, the following is stored in `auth_users_identities`:
-
-| Column | Contains |
-|--------|---------|
-| `type` | `oauth_{provider}` (e.g., `oauth_google`) |
-| `secret` | Provider's user ID |
-| `secret2` | Access token |
-| `extra` | Refresh token (if provided) |
-| `expires` | Access token expiry timestamp |
-
 ### Refresh an Access Token
 
 ```php
 use Daycry\Auth\Libraries\Oauth\OauthManager;
 
 $user    = auth()->user();
-$manager = new OauthManager(config('Auth'));
+$manager = new OauthManager(config('AuthOAuth'));
 $manager->setProvider('azure');
 
 $newToken = $manager->refreshAccessToken($user);
@@ -317,27 +531,132 @@ if ($newToken !== null) {
 
     // Make an API call with the fresh token
 } else {
-    // Refresh failed — redirect to login
+    // Refresh failed (no identity, no refresh token, or provider error)
     return redirect()->route('login');
 }
 ```
 
-### Check Token Expiry Before API Calls
+When a token is refreshed:
+- The new access token replaces the old one in `secret2`
+- If the provider rotates the refresh token, the new one is stored
+- If the refreshed token includes scopes, `scopes_granted` is updated
+- The existing `profile` and `profile_fetched_at` are preserved (no re-fetch on refresh)
+
+### Error Handling
+
+`refreshAccessToken()` returns `null` in these cases:
+- No OAuth identity found for the user/provider
+- The identity has no `extra` data or no `refresh_token` in the extra
+- The provider rejects the refresh (e.g., token revoked, expired)
+
+The method catches `IdentityProviderException` internally and returns `null` rather than throwing.
+
+---
+
+## OAuth Events
+
+`OauthManager::handleCallback()` fires two events after a successful OAuth login:
+
+| Event | When | Arguments |
+|-------|------|-----------|
+| `oauth-login` | Always, after login | `User $user`, `string $providerName` |
+| `oauth-profile-fetched` | When profile fields were resolved | `User $user`, `string $providerName`, `array $profileData` |
+
+### Listening to OAuth Events
 
 ```php
-$manager = new OauthManager(config('Auth'));
-$manager->setProvider('google');
+// app/Config/Events.php
+use CodeIgniter\Events\Events;
 
-$token = $manager->getStoredToken($user);
+// Log all OAuth logins
+Events::on('oauth-login', static function (object $user, string $provider): void {
+    log_message('info', "OAuth login via {$provider} for user {$user->email}");
+});
 
-if ($token !== null && $token->hasExpired()) {
-    $token = $manager->refreshAccessToken($user);
-}
+// Sync profile data to local tables
+Events::on('oauth-profile-fetched', static function (object $user, string $provider, array $profileData): void {
+    if (isset($profileData['department'])) {
+        // Update user's department in a custom table
+        db_connect()->table('user_profiles')->upsert([
+            'user_id'    => $user->id,
+            'department' => $profileData['department'],
+            'updated_at' => date('Y-m-d H:i:s'),
+        ], ['user_id']);
+    }
+});
 
-if ($token !== null) {
-    // Use $token->getToken() for the Google API
-}
+// Alert on first-time OAuth logins
+Events::on('oauth-login', static function (object $user, string $provider): void {
+    $identityCount = model(\Daycry\Auth\Models\UserIdentityModel::class)
+        ->where('user_id', $user->id)
+        ->like('type', 'oauth_', 'after')
+        ->countAllResults();
+
+    if ($identityCount === 1) {
+        // First OAuth link — send notification
+        log_message('info', "New OAuth account linked: {$provider} for {$user->email}");
+    }
+});
 ```
+
+---
+
+## OAuthTokenRepository
+
+`OAuthTokenRepository` encapsulates all OAuth identity CRUD, following the same pattern as `AccessTokenRepository` and `JwtTokenRepository`. It wraps `UserIdentityModel` and uses `IdentityType::oauthProvider()` for type strings.
+
+### Available Methods
+
+| Method | Description |
+|--------|-------------|
+| `findByUserAndProvider(int $userId, string $provider)` | Find the OAuth identity for a user/provider pair |
+| `findByProviderAndSocialId(string $provider, string $socialId)` | Find by provider type and social ID |
+| `createOAuthIdentity(int $userId, string $provider, array $data)` | Insert a new OAuth identity row |
+| `updateOAuthIdentity(UserIdentity $identity)` | Update an existing identity (token refresh, re-login) |
+| `getProfileData(int $userId, string $provider)` | Get the stored profile data from the `extra` JSON |
+| `parseExtra(?string $extra)` | Parse the `extra` column (handles JSON and legacy plain-string format) |
+
+### Direct Usage
+
+```php
+use Daycry\Auth\Models\OAuthTokenRepository;
+use Daycry\Auth\Models\UserIdentityModel;
+
+$repo = new OAuthTokenRepository(model(UserIdentityModel::class));
+
+// Find an OAuth identity
+$identity = $repo->findByUserAndProvider((int) $user->id, 'google');
+
+if ($identity !== null) {
+    $extra = $repo->parseExtra($identity->extra);
+    $accessToken  = $identity->secret2;
+    $refreshToken = $extra['refresh_token'] ?? null;
+    $scopes       = $extra['scopes_granted'] ?? [];
+    $profile      = $extra['profile'] ?? [];
+}
+
+// Get just the profile data
+$profile = $repo->getProfileData((int) $user->id, 'azure');
+// ['department' => 'Engineering', 'jobTitle' => 'Senior Dev']
+```
+
+`OauthManager` uses the repository internally via a lazy-initialised getter. You generally don't need to use it directly unless building custom OAuth integrations.
+
+---
+
+## IdentityType Helper
+
+OAuth identity types are dynamic (`oauth_google`, `oauth_github`, etc.) because the set of providers is user-defined. Instead of concatenating strings manually, use the static helper:
+
+```php
+use Daycry\Auth\Enums\IdentityType;
+
+// Instead of: 'oauth_' . $providerName
+$type = IdentityType::oauthProvider('google');  // 'oauth_google'
+$type = IdentityType::oauthProvider('azure');   // 'oauth_azure'
+```
+
+This centralises the `oauth_` prefix convention and makes OAuth type strings grep-able across the codebase.
 
 ---
 
@@ -379,35 +698,138 @@ The unlink logic ensures users always retain at least one way to sign in. It wil
 
 When a user authenticates via OAuth, the system:
 
-1. **Finds the user by email** — if an account with that email exists, the OAuth identity is linked to it
-2. **Creates a new account** — if no matching email is found, a new user is created automatically
-3. **Stores the provider identity** — the OAuth provider ID and tokens are saved in `auth_users_identities`
+1. **Looks up by social ID** -- if an OAuth identity with the same provider and social ID already exists, the tokens and profile are updated (re-login)
+2. **Finds the user by email** -- if no OAuth identity exists but an account with that email does, the OAuth identity is linked to it
+3. **Creates a new account** -- if no matching email is found, a new user is created automatically and assigned to the default group
+4. **Stores the provider identity** -- the OAuth provider ID, tokens, scopes, and profile data are saved in `auth_users_identities`
 
 ### Handling New Users from OAuth
 
-Listen to the `registered` event to run onboarding logic for users who sign up via OAuth:
+Listen to the `oauth-login` event to run onboarding logic for users who sign up via OAuth:
 
 ```php
 // app/Config/Events.php
 use CodeIgniter\Events\Events;
 
-Events::on('registered', static function (object $user): void {
-    // Assign default group
-    model(\Daycry\Auth\Models\UserModel::class)->addToDefaultGroup($user);
-
-    // Send welcome email
-    service('email')
-        ->setTo($user->email)
-        ->setSubject('Welcome!')
-        ->setMessage(view('emails/welcome', ['user' => $user]))
-        ->send();
+Events::on('oauth-login', static function (object $user, string $provider): void {
+    // Check if this is a brand new user (no other identities)
+    // The default group is assigned automatically during OAuth registration.
 });
 ```
 
 ---
 
-🔗 **See also**:
-- [Authentication](03-authentication.md) — All authentication methods
-- [Configuration](02-configuration.md) — Full `$providers` reference
-- [Controllers](05-controllers.md) — Custom OAuth controller patterns
-- [UserSecurityController](05-controllers.md#usersecuritycontroller) — Unlink and change email
+## Testing OAuth
+
+### Mocking the Provider
+
+`OauthManager::setProviderInstance()` accepts a mock provider for testing:
+
+```php
+use Daycry\Auth\Libraries\Oauth\OauthManager;
+use Daycry\Auth\Config\AuthOAuth;
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Provider\GenericResourceOwner;
+use League\OAuth2\Client\Token\AccessToken;
+use Mockery;
+
+$provider    = Mockery::mock(AbstractProvider::class);
+$accessToken = new AccessToken([
+    'access_token'  => 'test_token',
+    'refresh_token' => 'refresh_abc',
+    'scope'         => 'openid profile email',
+]);
+
+$provider->shouldReceive('getAccessToken')
+    ->with('authorization_code', ['code' => 'auth_code'])
+    ->andReturn($accessToken);
+
+$resourceOwner = Mockery::mock(GenericResourceOwner::class);
+$resourceOwner->shouldReceive('getId')->andReturn('social_123');
+$resourceOwner->shouldReceive('toArray')->andReturn([
+    'email' => 'test@example.com',
+    'name'  => 'Test User',
+    'role'  => 'admin',
+]);
+
+$provider->shouldReceive('getResourceOwner')
+    ->with($accessToken)
+    ->andReturn($resourceOwner);
+
+$manager = new OauthManager(new AuthOAuth());
+$manager->setProviderInstance($provider, 'generic');
+
+session()->set('oauth2state', 'valid_state');
+$user = $manager->handleCallback('auth_code', 'valid_state');
+```
+
+### Testing Events
+
+```php
+use CodeIgniter\Events\Events;
+
+$triggered = false;
+Events::on('oauth-login', static function ($user, $providerName) use (&$triggered): void {
+    $triggered = true;
+});
+
+// ... perform OAuth callback ...
+
+$this->assertTrue($triggered);
+```
+
+### Testing the Repository
+
+```php
+use Daycry\Auth\Models\OAuthTokenRepository;
+use Daycry\Auth\Models\UserIdentityModel;
+use Daycry\Auth\Enums\IdentityType;
+
+$repo = new OAuthTokenRepository(model(UserIdentityModel::class));
+
+// Test parseExtra with JSON
+$result = $repo->parseExtra('{"refresh_token": "rt", "profile": {"a": 1}}');
+$this->assertSame('rt', $result['refresh_token']);
+
+// Test parseExtra with legacy string
+$result = $repo->parseExtra('plain_token_string');
+$this->assertSame(['refresh_token' => 'plain_token_string'], $result);
+
+// Test parseExtra with null/empty
+$this->assertSame([], $repo->parseExtra(null));
+$this->assertSame([], $repo->parseExtra(''));
+```
+
+### Testing the ProfileResolverFactory
+
+```php
+use Daycry\Auth\Libraries\Oauth\ProfileResolver\ProfileResolverFactory;
+use Daycry\Auth\Libraries\Oauth\ProfileResolver\AzureProfileResolver;
+use Daycry\Auth\Libraries\Oauth\ProfileResolver\GenericProfileResolver;
+
+// Built-in map
+$this->assertInstanceOf(AzureProfileResolver::class, ProfileResolverFactory::create('azure'));
+
+// Fallback
+$this->assertInstanceOf(GenericProfileResolver::class, ProfileResolverFactory::create('unknown'));
+
+// Config-based override
+$resolver = ProfileResolverFactory::create('azure', [
+    'profileResolver' => GenericProfileResolver::class,
+]);
+$this->assertInstanceOf(GenericProfileResolver::class, $resolver);
+
+// Invalid resolver throws LogicException
+$this->expectException(\CodeIgniter\Exceptions\LogicException::class);
+ProfileResolverFactory::create('test', ['profileResolver' => \stdClass::class]);
+```
+
+---
+
+See also:
+- [Authentication](03-authentication.md) -- All authentication methods
+- [Configuration](02-configuration.md) -- Full `$providers` reference
+- [Controllers](05-controllers.md) -- Custom OAuth controller patterns
+- [UserSecurityController](05-controllers.md#usersecuritycontroller) -- Unlink and change email
+- [Logging & Monitoring](07-logging.md) -- OAuth events and logging
+- [Testing](08-testing.md) -- Complete testing guide

--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,10 @@ Complete documentation for **Daycry Auth**, a comprehensive authentication and a
 ### [OAuth 2.0 & Social Login](09-oauth.md)
 - Google, GitHub, Facebook, Microsoft Azure
 - Generic OIDC provider
+- Profile fields & custom resolvers
+- OAuth events (`oauth-login`, `oauth-profile-fetched`)
+- Scopes granted tracking
+- OAuthTokenRepository
 - Refresh token handling
 - Unlinking providers
 
@@ -99,6 +103,9 @@ Complete documentation for **Daycry Auth**, a comprehensive authentication and a
 | Bootstrap 5 Admin Panel | ✅ Complete |
 | Email Change Confirmation | ✅ Complete |
 | OAuth Provider Unlinking | ✅ Complete |
+| OAuth Profile Fields & Resolvers | ✅ Complete |
+| OAuth Events | ✅ Complete |
+| OAuthTokenRepository | ✅ Complete |
 | Pre-Auth Events | ✅ Complete |
 | Self-Service Password Change | ✅ Complete |
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,7 +52,7 @@ Welcome to the complete documentation for **Daycry Auth**, a comprehensive authe
 - **Force Password Reset**: Flag accounts for mandatory password change
 - **Permission System**: Groups and granular permissions with optional cache
 - **Flexible Filters**: Auth, chain, group, permission, rate limiting, force-reset
-- **OAuth 2.0 / Social Login**: Google, GitHub, Facebook, Microsoft Azure
+- **OAuth 2.0 / Social Login**: Google, GitHub, Facebook, Microsoft Azure, custom profile fields, OAuth events
 - **Per-User Account Lockout**: Independent of IP-based blocking
 - **Complete Logging**: CI4 Events + database login attempt logs
 - **Highly Customizable**: Extend or replace any component
@@ -86,7 +86,7 @@ Every configuration option explained with examples.
 Session, Access Token, JWT (with refresh), Magic Link, Password Reset, and more.
 
 ### [OAuth 2.0 & Social Login](09-oauth.md)
-Google, GitHub, Facebook, Microsoft Azure — and any OIDC provider.
+Google, GitHub, Facebook, Microsoft Azure — and any OIDC provider. Profile fields, custom resolvers, OAuth events, scopes tracking.
 
 ### [TOTP Two-Factor Authentication](10-totp-2fa.md)
 Time-based OTP with authenticator apps.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -3,8 +3,8 @@ parameters:
 		-
 			rawMessage: Call to function model with Daycry\Auth\Models\UserIdentityModel::class is discouraged.
 			identifier: codeigniter.factoriesClassConstFetch
-			count: 2
-			path: src/Authentication/Actions/Email2FA.php
+			count: 1
+			path: src/Authentication/Actions/AbstractAction.php
 
 		-
 			rawMessage: 'Call to internal function emailer().'
@@ -13,22 +13,10 @@ parameters:
 			path: src/Authentication/Actions/Email2FA.php
 
 		-
-			rawMessage: Call to function model with Daycry\Auth\Models\UserIdentityModel::class is discouraged.
-			identifier: codeigniter.factoriesClassConstFetch
-			count: 2
-			path: src/Authentication/Actions/EmailActivator.php
-
-		-
 			rawMessage: 'Call to internal function emailer().'
 			identifier: function.internal
 			count: 1
 			path: src/Authentication/Actions/EmailActivator.php
-
-		-
-			rawMessage: Call to function model with Daycry\Auth\Models\UserIdentityModel::class is discouraged.
-			identifier: codeigniter.factoriesClassConstFetch
-			count: 3
-			path: src/Authentication/Actions/Totp2FA.php
 
 		-
 			rawMessage: 'Call to an undefined method CodeIgniter\HTTP\Request::getGetPost().'
@@ -39,6 +27,15 @@ parameters:
 		-
 			rawMessage: 'Call to an undefined method CodeIgniter\HTTP\Request::getVar().'
 			identifier: method.notFound
+			count: 1
+			path: src/Authentication/Authenticators/AccessToken.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method getAccessTokenByRawToken() of class Daycry\Auth\Models\UserIdentityModel:
+				Use AccessTokenRepository::getAccessTokenByRawToken() instead.
+			'''
+			identifier: method.deprecated
 			count: 1
 			path: src/Authentication/Authenticators/AccessToken.php
 
@@ -142,12 +139,6 @@ parameters:
 			rawMessage: Access to property $csrfProtection on an unknown class Daycry\Auth\Authentication\Authenticators\Security.
 			identifier: class.notFound
 			count: 1
-			path: src/Authentication/Authenticators/Session.php
-
-		-
-			rawMessage: Call to function model with Daycry\Auth\Models\DeviceSessionModel::class is discouraged.
-			identifier: codeigniter.factoriesClassConstFetch
-			count: 2
 			path: src/Authentication/Authenticators/Session.php
 
 		-
@@ -287,6 +278,12 @@ parameters:
 			identifier: varTag.type
 			count: 1
 			path: src/Authentication/Passwords/PwnedValidator.php
+
+		-
+			rawMessage: Call to function model with Daycry\Auth\Models\DeviceSessionModel::class is discouraged.
+			identifier: codeigniter.factoriesClassConstFetch
+			count: 2
+			path: src/Authentication/Services/DeviceSessionRecorder.php
 
 		-
 			rawMessage: Call to unknown service method 'settings'.
@@ -457,6 +454,12 @@ parameters:
 			path: src/Controllers/Admin/UsersController.php
 
 		-
+			rawMessage: Call to function model with Daycry\Auth\Models\LoginModel::class is discouraged.
+			identifier: codeigniter.factoriesClassConstFetch
+			count: 1
+			path: src/Controllers/BaseAuthController.php
+
+		-
 			rawMessage: 'Method Daycry\Auth\Controllers\BaseAuthController::getSessionAuthenticator() should return Daycry\Auth\Authentication\Authenticators\Session but returns Daycry\Auth\Interfaces\AuthenticatorInterface.'
 			identifier: return.type
 			count: 1
@@ -487,6 +490,24 @@ parameters:
 			path: src/Controllers/ForcePasswordResetController.php
 
 		-
+			rawMessage: '''
+				Call to deprecated method createJwtRefreshToken() of class Daycry\Auth\Models\UserIdentityModel:
+				Use JwtTokenRepository::createRefreshToken() instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/Controllers/JwtController.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method getJwtRefreshToken() of class Daycry\Auth\Models\UserIdentityModel:
+				Use JwtTokenRepository::getRefreshToken() instead.
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: src/Controllers/JwtController.php
+
+		-
 			rawMessage: Call to function model with Daycry\Auth\Models\UserIdentityModel::class is discouraged.
 			identifier: codeigniter.factoriesClassConstFetch
 			count: 3
@@ -499,7 +520,7 @@ parameters:
 			path: src/Controllers/JwtController.php
 
 		-
-			rawMessage: Call to function model with Daycry\Auth\Models\LoginModel::class is discouraged.
+			rawMessage: Call to function model with Daycry\Auth\Models\UserIdentityModel::class is discouraged.
 			identifier: codeigniter.factoriesClassConstFetch
 			count: 1
 			path: src/Controllers/MagicLinkController.php
@@ -508,35 +529,11 @@ parameters:
 			rawMessage: Call to function model with Daycry\Auth\Models\UserIdentityModel::class is discouraged.
 			identifier: codeigniter.factoriesClassConstFetch
 			count: 2
-			path: src/Controllers/MagicLinkController.php
-
-		-
-			rawMessage: 'Call to internal function emailer().'
-			identifier: function.internal
-			count: 1
-			path: src/Controllers/MagicLinkController.php
-
-		-
-			rawMessage: Call to function model with Daycry\Auth\Models\LoginModel::class is discouraged.
-			identifier: codeigniter.factoriesClassConstFetch
-			count: 1
-			path: src/Controllers/PasswordResetController.php
-
-		-
-			rawMessage: Call to function model with Daycry\Auth\Models\UserIdentityModel::class is discouraged.
-			identifier: codeigniter.factoriesClassConstFetch
-			count: 3
 			path: src/Controllers/PasswordResetController.php
 
 		-
 			rawMessage: Call to function model with Daycry\Auth\Models\UserModel::class is discouraged.
 			identifier: codeigniter.factoriesClassConstFetch
-			count: 1
-			path: src/Controllers/PasswordResetController.php
-
-		-
-			rawMessage: 'Call to internal function emailer().'
-			identifier: function.internal
 			count: 1
 			path: src/Controllers/PasswordResetController.php
 
@@ -747,6 +744,51 @@ parameters:
 		-
 			rawMessage: 'Call to an undefined method Daycry\Auth\Models\UserIdentityModel::revokeAllAccessTokens().'
 			identifier: method.notFound
+			count: 1
+			path: src/Entities/User.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method generateAccessToken() of class Daycry\Auth\Models\UserIdentityModel:
+				Use AccessTokenRepository::generateAccessToken() instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/Entities/User.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method getAccessToken() of class Daycry\Auth\Models\UserIdentityModel:
+				Use AccessTokenRepository::getAccessToken() instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/Entities/User.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method getAccessTokenById() of class Daycry\Auth\Models\UserIdentityModel:
+				Use AccessTokenRepository::getAccessTokenById() instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/Entities/User.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method revokeAccessToken() of class Daycry\Auth\Models\UserIdentityModel:
+				Use AccessTokenRepository::deleteAccessToken() or softRevokeAccessToken() instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/Entities/User.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method revokeAccessTokenBySecret() of class Daycry\Auth\Models\UserIdentityModel:
+				Use AccessTokenRepository::deleteAccessTokenBySecret() or softRevokeAccessTokenBySecret() instead.
+			'''
+			identifier: method.deprecated
 			count: 1
 			path: src/Entities/User.php
 
@@ -1011,7 +1053,7 @@ parameters:
 		-
 			rawMessage: Call to function model with Daycry\Auth\Models\UserIdentityModel::class is discouraged.
 			identifier: codeigniter.factoriesClassConstFetch
-			count: 2
+			count: 1
 			path: src/Libraries/Oauth/OauthManager.php
 
 		-
@@ -1019,6 +1061,63 @@ parameters:
 			identifier: argument.type
 			count: 1
 			path: src/Libraries/Oauth/OauthManager.php
+
+		-
+			rawMessage: Call to function model with Daycry\Auth\Models\UserIdentityModel::class is discouraged.
+			identifier: codeigniter.factoriesClassConstFetch
+			count: 1
+			path: src/Libraries/TokenEmailSender.php
+
+		-
+			rawMessage: 'Call to internal function emailer().'
+			identifier: function.internal
+			count: 1
+			path: src/Libraries/TokenEmailSender.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method generateAccessToken() of class Daycry\Auth\Models\UserIdentityModel:
+				Use AccessTokenRepository::generateAccessToken() instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/Models/AccessTokenRepository.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method getAccessToken() of class Daycry\Auth\Models\UserIdentityModel:
+				Use AccessTokenRepository::getAccessToken() instead.
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: src/Models/AccessTokenRepository.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method getAccessTokenById() of class Daycry\Auth\Models\UserIdentityModel:
+				Use AccessTokenRepository::getAccessTokenById() instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/Models/AccessTokenRepository.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method getAccessTokenByRawToken() of class Daycry\Auth\Models\UserIdentityModel:
+				Use AccessTokenRepository::getAccessTokenByRawToken() instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/Models/AccessTokenRepository.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method getAllAccessToken() of class Daycry\Auth\Models\UserIdentityModel:
+				Use AccessTokenRepository::getAllAccessTokens() instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/Models/AccessTokenRepository.php
 
 		-
 			rawMessage: Call to unknown service method 'settings'.
@@ -1037,6 +1136,24 @@ parameters:
 			identifier: varTag.variableNotFound
 			count: 1
 			path: src/Models/DeviceSessionModel.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method createJwtRefreshToken() of class Daycry\Auth\Models\UserIdentityModel:
+				Use JwtTokenRepository::createRefreshToken() instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/Models/JwtTokenRepository.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method getJwtRefreshToken() of class Daycry\Auth\Models\UserIdentityModel:
+				Use JwtTokenRepository::getRefreshToken() instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: src/Models/JwtTokenRepository.php
 
 		-
 			rawMessage: PHPDoc tag @param for parameter $userId with type int|string|null is not subtype of native type int|null.
@@ -1540,9 +1657,51 @@ parameters:
 			path: tests/Libraries/LoggerTest.php
 
 		-
+			rawMessage: 'Call to an undefined method Mockery\ExpectationInterface|Mockery\HigherOrderMessage::andThrow().'
+			identifier: method.notFound
+			count: 1
+			path: tests/Libraries/Oauth/ProfileResolver/AzureProfileResolverTest.php
+
+		-
+			rawMessage: 'Parameter #1 $provider of method Daycry\Auth\Libraries\Oauth\ProfileResolver\AzureProfileResolver::fetchFields() expects League\OAuth2\Client\Provider\AbstractProvider, Mockery\MockInterface given.'
+			identifier: argument.type
+			count: 4
+			path: tests/Libraries/Oauth/ProfileResolver/AzureProfileResolverTest.php
+
+		-
+			rawMessage: 'Parameter #3 $resourceOwner of method Daycry\Auth\Libraries\Oauth\ProfileResolver\AzureProfileResolver::fetchFields() expects League\OAuth2\Client\Provider\ResourceOwnerInterface, Mockery\MockInterface given.'
+			identifier: argument.type
+			count: 4
+			path: tests/Libraries/Oauth/ProfileResolver/AzureProfileResolverTest.php
+
+		-
 			rawMessage: 'Call to an undefined method Mockery\ExpectationInterface|Mockery\HigherOrderMessage::with().'
 			identifier: method.notFound
 			count: 2
+			path: tests/Libraries/Oauth/ProfileResolver/GenericProfileResolverTest.php
+
+		-
+			rawMessage: 'Parameter #1 $provider of method Daycry\Auth\Libraries\Oauth\ProfileResolver\GenericProfileResolver::fetchFields() expects League\OAuth2\Client\Provider\AbstractProvider, Mockery\MockInterface given.'
+			identifier: argument.type
+			count: 5
+			path: tests/Libraries/Oauth/ProfileResolver/GenericProfileResolverTest.php
+
+		-
+			rawMessage: 'Parameter #3 $resourceOwner of method Daycry\Auth\Libraries\Oauth\ProfileResolver\GenericProfileResolver::fetchFields() expects League\OAuth2\Client\Provider\ResourceOwnerInterface, Mockery\MockInterface given.'
+			identifier: argument.type
+			count: 5
+			path: tests/Libraries/Oauth/ProfileResolver/GenericProfileResolverTest.php
+
+		-
+			rawMessage: 'Call to an undefined method Mockery\ExpectationInterface|Mockery\HigherOrderMessage::andThrow().'
+			identifier: method.notFound
+			count: 1
+			path: tests/Libraries/OauthManagerTest.php
+
+		-
+			rawMessage: 'Call to an undefined method Mockery\ExpectationInterface|Mockery\HigherOrderMessage::with().'
+			identifier: method.notFound
+			count: 18
 			path: tests/Libraries/OauthManagerTest.php
 
 		-
@@ -1554,13 +1713,25 @@ parameters:
 		-
 			rawMessage: 'Call to method PHPUnit\Framework\Assert::assertInstanceOf() with ''Daycry\\Auth\\Entities\\User'' and Daycry\Auth\Entities\User will always evaluate to true.'
 			identifier: method.alreadyNarrowedType
-			count: 1
+			count: 2
 			path: tests/Libraries/OauthManagerTest.php
 
 		-
 			rawMessage: 'Parameter #1 $provider of method Daycry\Auth\Libraries\Oauth\OauthManager::setProviderInstance() expects League\OAuth2\Client\Provider\AbstractProvider, Mockery\MockInterface given.'
 			identifier: argument.type
-			count: 3
+			count: 17
+			path: tests/Libraries/OauthManagerTest.php
+
+		-
+			rawMessage: 'Parameter #2 $callback of static method CodeIgniter\Events\Events::on() expects callable(mixed): mixed, Closure(mixed, mixed): void given.'
+			identifier: argument.type
+			count: 1
+			path: tests/Libraries/OauthManagerTest.php
+
+		-
+			rawMessage: 'Parameter #2 $callback of static method CodeIgniter\Events\Events::on() expects callable(mixed): mixed, Closure(mixed, mixed, mixed): void given.'
+			identifier: argument.type
+			count: 1
 			path: tests/Libraries/OauthManagerTest.php
 
 		-

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -268,6 +268,12 @@ parameters:
 			path: src/Authentication/Authenticators/StatelessAuthenticator.php
 
 		-
+			rawMessage: 'Parameter #1 $name of function config expects a valid class string, ''JWT'' given.'
+			identifier: codeigniter.configArgumentType
+			count: 2
+			path: src/Authentication/JWT/Adapters/DaycryJWTAdapter.php
+
+		-
 			rawMessage: 'Call to method Daycry\Auth\Result::isOK() with incorrect case: isOk'
 			identifier: method.nameCase
 			count: 1

--- a/src/Auth.php
+++ b/src/Auth.php
@@ -17,31 +17,47 @@ use CodeIgniter\Router\RouteCollection;
 use Daycry\Auth\Authentication\Authentication;
 use Daycry\Auth\Config\Auth as AuthConfig;
 use Daycry\Auth\Entities\User;
+use Daycry\Auth\Entities\UserIdentity;
 use Daycry\Auth\Exceptions\AuthenticationException;
+use Daycry\Auth\Interfaces\ActionInterface;
 use Daycry\Auth\Interfaces\AuthenticatorInterface;
 use Daycry\Auth\Interfaces\UserProviderInterface;
 
 /**
  * Facade for Authentication
  *
- * @method Result    attempt(array $credentials)
- * @method Result    check(array $credentials)
- * @method bool      checkAction(string $token, string $type) [Session]
- * @method void      forget(?User $user = null)               [Session]
+ * Common methods (all authenticators):
+ *
+ * @method Result               attempt(array $credentials)
+ * @method Result               check(array $credentials)
+ * @method bool                 checkAction(UserIdentity $identity, string $token)
+ * @method void                 completeLogin(User $user)
+ * @method void                 forget(?User $user = null)
+ * @method ActionInterface|null getAction()
+ * @method mixed                getLogCredentials(array $credentials)
+ *
+ * Session-only methods:
+ * @method string    getPendingMessage()
+ * @method User|null getPendingUser()
  * @method User|null getUser()
+ * @method bool      hasAction(int|string|null $userId = null)
+ * @method bool      isAnonymous()
+ * @method bool      isPending()
  * @method bool      loggedIn()
- * @method bool      login(User $user)
- * @method void      loginById($userId)
- * @method bool      logout()
+ * @method void      login(User $user, bool $actions = true)
+ * @method void      loginById(int|string $userId)
+ * @method void      logout()
  * @method void      recordActiveDate()
- * @method $this     remember(bool $shouldRemember = true)    [Session]
+ * @method self      remember(bool $shouldRemember = true)
+ * @method void      startLogin(User $user)
+ * @method bool      startUpAction(string $type, User $user)
  */
 class Auth
 {
     /**
      * The current version of CodeIgniter Shield
      */
-    public const SHIELD_VERSION = '3.0.5';
+    public const SHIELD_VERSION = '5.0.0';
 
     protected ?UserProviderInterface $userProvider = null;
     protected ?Authentication $authenticate        = null;

--- a/src/Authentication/Actions/AbstractAction.php
+++ b/src/Authentication/Actions/AbstractAction.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Daycry\Auth\Authentication\Actions;
+
+use CodeIgniter\Exceptions\RuntimeException;
+use Daycry\Auth\Authentication\Authenticators\Session;
+use Daycry\Auth\Entities\User;
+use Daycry\Auth\Entities\UserIdentity;
+use Daycry\Auth\Interfaces\ActionInterface;
+use Daycry\Auth\Models\UserIdentityModel;
+use Daycry\Auth\Traits\Viewable;
+
+/**
+ * Base class for post-authentication actions (Email2FA, EmailActivator, Totp2FA).
+ *
+ * Provides shared helpers so concrete actions only implement their
+ * action-specific logic.
+ */
+abstract class AbstractAction implements ActionInterface
+{
+    use Viewable;
+
+    /**
+     * The identity type this action operates on.
+     */
+    protected string $type;
+
+    /**
+     * Returns the pending-login user from the session authenticator.
+     *
+     * @throws RuntimeException When no pending user exists.
+     */
+    protected function requirePendingUser(): User
+    {
+        /** @var Session $authenticator */
+        $authenticator = auth('session')->getAuthenticator();
+
+        $user = $authenticator->getPendingUser();
+
+        if ($user === null) {
+            throw new RuntimeException('Cannot get the pending login User.');
+        }
+
+        return $user;
+    }
+
+    /**
+     * Returns the session authenticator instance.
+     */
+    protected function getSessionAuthenticator(): Session
+    {
+        /** @var Session */
+        return auth('session')->getAuthenticator();
+    }
+
+    /**
+     * Returns the UserIdentityModel instance.
+     */
+    protected function getIdentityModel(): UserIdentityModel
+    {
+        /** @var UserIdentityModel */
+        return model(UserIdentityModel::class);
+    }
+
+    /**
+     * Returns an identity for this action type for the given user.
+     */
+    protected function getIdentity(User $user): ?UserIdentity
+    {
+        return $this->getIdentityModel()->getIdentityByType($user, $this->type);
+    }
+
+    /**
+     * Returns the string type of the action class.
+     */
+    public function getType(): string
+    {
+        return $this->type;
+    }
+}

--- a/src/Authentication/Actions/Email2FA.php
+++ b/src/Authentication/Actions/Email2FA.php
@@ -20,21 +20,16 @@ use CodeIgniter\I18n\Time;
 use Daycry\Auth\Authentication\Authenticators\Session;
 use Daycry\Auth\Entities\User;
 use Daycry\Auth\Entities\UserIdentity;
-use Daycry\Auth\Interfaces\ActionInterface;
 use Daycry\Auth\Libraries\Utils;
-use Daycry\Auth\Models\UserIdentityModel;
-use Daycry\Auth\Traits\Viewable;
 
 /**
  * Class Email2FA
  *
  * Sends an email to the user with a code to verify their account.
  */
-class Email2FA implements ActionInterface
+class Email2FA extends AbstractAction
 {
-    use Viewable;
-
-    private string $type = Session::ID_TYPE_EMAIL_2FA;
+    protected string $type = Session::ID_TYPE_EMAIL_2FA;
 
     /**
      * Displays the "Hey we're going to send you a number to your email"
@@ -42,13 +37,7 @@ class Email2FA implements ActionInterface
      */
     public function show(): string
     {
-        /** @var Session $authenticator */
-        $authenticator = auth('session')->getAuthenticator();
-
-        $user = $authenticator->getPendingUser();
-        if ($user === null) {
-            throw new RuntimeException('Cannot get the pending login User.');
-        }
+        $user = $this->requirePendingUser();
 
         $this->createIdentity($user);
 
@@ -66,13 +55,7 @@ class Email2FA implements ActionInterface
     {
         $email = $request->getPost('email');
 
-        /** @var Session $authenticator */
-        $authenticator = auth('session')->getAuthenticator();
-
-        $user = $authenticator->getPendingUser();
-        if ($user === null) {
-            throw new RuntimeException('Cannot get the pending login User.');
-        }
+        $user = $this->requirePendingUser();
 
         if (empty($email) || $email !== $user->email) {
             return redirect()->route('auth-action-show')->with('error', lang('Auth.invalidEmail'));
@@ -117,8 +100,7 @@ class Email2FA implements ActionInterface
      */
     public function verify(IncomingRequest $request)
     {
-        /** @var Session $authenticator */
-        $authenticator = auth('session')->getAuthenticator();
+        $authenticator = $this->getSessionAuthenticator();
 
         $postedToken = $request->getPost('token');
 
@@ -147,8 +129,7 @@ class Email2FA implements ActionInterface
      */
     public function createIdentity(User $user): string
     {
-        /** @var UserIdentityModel $identityModel */
-        $identityModel = model(UserIdentityModel::class);
+        $identityModel = $this->getIdentityModel();
 
         // Delete any previous identities for action
         $identityModel->deleteIdentitiesByType($user, $this->type);
@@ -162,27 +143,5 @@ class Email2FA implements ActionInterface
             ],
             static fn (): string => Utils::generateNumericCode(),
         );
-    }
-
-    /**
-     * Returns an identity for the action of the user.
-     */
-    private function getIdentity(User $user): ?UserIdentity
-    {
-        /** @var UserIdentityModel $identityModel */
-        $identityModel = model(UserIdentityModel::class);
-
-        return $identityModel->getIdentityByType(
-            $user,
-            $this->type,
-        );
-    }
-
-    /**
-     * Returns the string type of the action class.
-     */
-    public function getType(): string
-    {
-        return $this->type;
     }
 }

--- a/src/Authentication/Actions/EmailActivator.php
+++ b/src/Authentication/Actions/EmailActivator.php
@@ -22,17 +22,16 @@ use CodeIgniter\HTTP\Response;
 use CodeIgniter\I18n\Time;
 use Daycry\Auth\Authentication\Authenticators\Session;
 use Daycry\Auth\Entities\User;
-use Daycry\Auth\Entities\UserIdentity;
-use Daycry\Auth\Interfaces\ActionInterface;
 use Daycry\Auth\Libraries\Utils;
-use Daycry\Auth\Models\UserIdentityModel;
-use Daycry\Auth\Traits\Viewable;
 
-class EmailActivator implements ActionInterface
+/**
+ * Class EmailActivator
+ *
+ * Sends an email to the user with a link to confirm their email address.
+ */
+class EmailActivator extends AbstractAction
 {
-    use Viewable;
-
-    private string $type = Session::ID_TYPE_EMAIL_ACTIVATE;
+    protected string $type = Session::ID_TYPE_EMAIL_ACTIVATE;
 
     /**
      * Shows the initial screen to the user telling them
@@ -41,13 +40,7 @@ class EmailActivator implements ActionInterface
      */
     public function show(): string
     {
-        /** @var Session $authenticator */
-        $authenticator = auth('session')->getAuthenticator();
-
-        $user = $authenticator->getPendingUser();
-        if ($user === null) {
-            throw new RuntimeException('Cannot get the pending login User.');
-        }
+        $user = $this->requirePendingUser();
 
         $userEmail = $user->email;
         if ($userEmail === null) {
@@ -106,8 +99,7 @@ class EmailActivator implements ActionInterface
      */
     public function verify(IncomingRequest $request)
     {
-        /** @var Session $authenticator */
-        $authenticator = auth('session')->getAuthenticator();
+        $authenticator = $this->getSessionAuthenticator();
 
         $postedToken = $request->getVar('token');
 
@@ -142,8 +134,7 @@ class EmailActivator implements ActionInterface
      */
     public function createIdentity(User $user): string
     {
-        /** @var UserIdentityModel $identityModel */
-        $identityModel = model(UserIdentityModel::class);
+        $identityModel = $this->getIdentityModel();
 
         // Delete any previous identities for action
         $identityModel->deleteIdentitiesByType($user, $this->type);
@@ -157,27 +148,5 @@ class EmailActivator implements ActionInterface
             ],
             static fn (): string => Utils::generateNumericCode(),
         );
-    }
-
-    /**
-     * Returns an identity for the action of the user.
-     */
-    private function getIdentity(User $user): ?UserIdentity
-    {
-        /** @var UserIdentityModel $identityModel */
-        $identityModel = model(UserIdentityModel::class);
-
-        return $identityModel->getIdentityByType(
-            $user,
-            $this->type,
-        );
-    }
-
-    /**
-     * Returns the string type of the action class.
-     */
-    public function getType(): string
-    {
-        return $this->type;
     }
 }

--- a/src/Authentication/Actions/Totp2FA.php
+++ b/src/Authentication/Actions/Totp2FA.php
@@ -16,14 +16,10 @@ namespace Daycry\Auth\Authentication\Actions;
 use CodeIgniter\Exceptions\RuntimeException;
 use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\RedirectResponse;
-use Daycry\Auth\Authentication\Authenticators\Session;
 use Daycry\Auth\Entities\User;
 use Daycry\Auth\Entities\UserIdentity;
 use Daycry\Auth\Enums\IdentityType;
-use Daycry\Auth\Interfaces\ActionInterface;
 use Daycry\Auth\Libraries\TOTP;
-use Daycry\Auth\Models\UserIdentityModel;
-use Daycry\Auth\Traits\Viewable;
 
 /**
  * Class Totp2FA
@@ -37,28 +33,19 @@ use Daycry\Auth\Traits\Viewable;
  * Users enable/disable TOTP from their account security settings via
  * UserSecurityController (totpSetup / totpDisable).
  */
-class Totp2FA implements ActionInterface
+class Totp2FA extends AbstractAction
 {
-    use Viewable;
-
     /**
      * Identity type for the pending-login marker.
      */
-    private string $type = IdentityType::TOTP->value;
+    protected string $type = IdentityType::TOTP->value;
 
     /**
      * Displays the TOTP code entry form.
      */
     public function show(): string
     {
-        /** @var Session $authenticator */
-        $authenticator = auth('session')->getAuthenticator();
-
-        $user = $authenticator->getPendingUser();
-
-        if ($user === null) {
-            throw new RuntimeException('Cannot get the pending login User.');
-        }
+        $this->requirePendingUser();
 
         return $this->view(setting('Auth.views')['action_totp_2fa_verify']);
     }
@@ -80,8 +67,7 @@ class Totp2FA implements ActionInterface
      */
     public function verify(IncomingRequest $request)
     {
-        /** @var Session $authenticator */
-        $authenticator = auth('session')->getAuthenticator();
+        $authenticator = $this->getSessionAuthenticator();
 
         $user = $authenticator->getPendingUser();
 
@@ -98,9 +84,7 @@ class Totp2FA implements ActionInterface
         }
 
         // Remove the pending marker and complete login
-        /** @var UserIdentityModel $identityModel */
-        $identityModel = model(UserIdentityModel::class);
-        $identityModel->deleteIdentitiesByType($user, $this->type);
+        $this->getIdentityModel()->deleteIdentitiesByType($user, $this->type);
 
         $authenticator->completeLogin($user);
 
@@ -118,8 +102,7 @@ class Totp2FA implements ActionInterface
      */
     public function createIdentity(User $user): string
     {
-        /** @var UserIdentityModel $identityModel */
-        $identityModel = model(UserIdentityModel::class);
+        $identityModel = $this->getIdentityModel();
 
         // Remove any stale marker from a previous attempt
         $identityModel->deleteIdentitiesByType($user, $this->type);
@@ -141,22 +124,11 @@ class Totp2FA implements ActionInterface
     }
 
     /**
-     * Returns the string type of this action.
-     */
-    public function getType(): string
-    {
-        return $this->type;
-    }
-
-    /**
      * Verifies the TOTP code against the user's permanent secret.
      */
     private function verifyCodeForUser(User $user, string $code): bool
     {
-        /** @var UserIdentityModel $identityModel */
-        $identityModel = model(UserIdentityModel::class);
-
-        $totpSecret = $identityModel->getIdentityByType($user, IdentityType::TOTP_SECRET->value);
+        $totpSecret = $this->getIdentityModel()->getIdentityByType($user, IdentityType::TOTP_SECRET->value);
 
         if (! $totpSecret instanceof UserIdentity) {
             return false;

--- a/src/Authentication/Authenticators/Session.php
+++ b/src/Authentication/Authenticators/Session.php
@@ -16,11 +16,12 @@ namespace Daycry\Auth\Authentication\Authenticators;
 use CodeIgniter\Config\Factories;
 use CodeIgniter\Events\Events;
 use CodeIgniter\Exceptions\LogicException;
-use CodeIgniter\HTTP\IncomingRequest;
 use CodeIgniter\HTTP\Request;
-use CodeIgniter\I18n\Time;
 use Config\Services;
+use Daycry\Auth\Authentication\Services\DeviceSessionRecorder;
+use Daycry\Auth\Authentication\Services\PendingActionCoordinator;
 use Daycry\Auth\Authentication\Services\RememberMe;
+use Daycry\Auth\Authentication\Services\UserLockoutManager;
 use Daycry\Auth\Entities\User;
 use Daycry\Auth\Entities\UserIdentity;
 use Daycry\Auth\Enums\AuthenticationState;
@@ -31,7 +32,6 @@ use Daycry\Auth\Exceptions\SecurityException;
 use Daycry\Auth\Interfaces\ActionInterface;
 use Daycry\Auth\Interfaces\AuthenticatorInterface;
 use Daycry\Auth\Interfaces\UserProviderInterface;
-use Daycry\Auth\Models\DeviceSessionModel;
 use Daycry\Auth\Models\LoginModel;
 use Daycry\Auth\Models\RememberModel;
 use Daycry\Auth\Models\UserIdentityModel;
@@ -61,6 +61,21 @@ class Session extends Base implements AuthenticatorInterface
      */
     protected bool $shouldRemember = false;
 
+    /**
+     * Manages per-user account lockout after repeated failed login attempts.
+     */
+    private UserLockoutManager $lockoutManager;
+
+    /**
+     * Handles creation and termination of device session records.
+     */
+    private DeviceSessionRecorder $deviceRecorder;
+
+    /**
+     * Coordinates post-authentication actions (Email2FA, EmailActivator, Totp2FA).
+     */
+    private PendingActionCoordinator $actionCoordinator;
+
     public function __construct(
         UserProviderInterface $provider,
         Request $request,
@@ -71,6 +86,10 @@ class Session extends Base implements AuthenticatorInterface
         $this->method = self::ID_TYPE_USERNAME;
 
         parent::__construct($provider, $request, $userIdentityModel, $loginModel);
+
+        $this->lockoutManager    = new UserLockoutManager($provider);
+        $this->deviceRecorder    = new DeviceSessionRecorder();
+        $this->actionCoordinator = new PendingActionCoordinator($userIdentityModel);
 
         $this->checkSecurityConfig();
     }
@@ -174,22 +193,9 @@ class Session extends Base implements AuthenticatorInterface
         }
 
         // Check per-user lockout (independent of IP-based blocking)
-        $maxAttempts = (int) setting('AuthSecurity.userMaxAttempts');
-
-        if ($maxAttempts > 0 && $user->locked_until !== null) {
-            $lockedUntil = Time::parse((string) $user->locked_until);
-
-            if ($lockedUntil->isAfter(Time::now())) {
-                $minutesLeft = (int) ceil(Time::now()->difference($lockedUntil)->getMinutes());
-
-                return new Result([
-                    'success' => false,
-                    'reason'  => lang('Auth.userLockedOut', [$minutesLeft]),
-                ]);
-            }
-
-            // Lockout has expired — reset counter automatically
-            $this->provider->update($user->id, ['failed_login_count' => 0, 'locked_until' => null]);
+        $lockoutResult = $this->lockoutManager->isLockedOut($user);
+        if ($lockoutResult !== null) {
+            return $lockoutResult;
         }
 
         /** @var Passwords $passwords */
@@ -197,19 +203,7 @@ class Session extends Base implements AuthenticatorInterface
 
         // Now, try matching the passwords.
         if (! $passwords->verify($givenPassword, $user->password_hash)) {
-            // Increment the per-user failed login counter
-            if ($maxAttempts > 0) {
-                $count = ((int) ($user->failed_login_count ?? 0)) + 1;
-                $data  = ['failed_login_count' => $count];
-
-                if ($count >= $maxAttempts) {
-                    $data['locked_until'] = Time::now()
-                        ->addSeconds((int) setting('AuthSecurity.userLockoutTime'))
-                        ->format('Y-m-d H:i:s');
-                }
-
-                $this->provider->update($user->id, $data);
-            }
+            $this->lockoutManager->recordFailedAttempt($user);
 
             return new Result([
                 'success' => false,
@@ -342,11 +336,7 @@ class Session extends Base implements AuthenticatorInterface
         $this->user = $user;
 
         // Reset per-user failed login counter on successful login
-        if ((int) setting('AuthSecurity.userMaxAttempts') > 0
-            && ((int) ($user->failed_login_count ?? 0) > 0 || $user->locked_until !== null)
-        ) {
-            $this->provider->update($user->id, ['failed_login_count' => 0, 'locked_until' => null]);
-        }
+        $this->lockoutManager->resetOnSuccess($user);
 
         if ($actions) {
             // Update the user's last used date on their password identity.
@@ -409,12 +399,7 @@ class Session extends Base implements AuthenticatorInterface
 
         // Terminate the device session record if tracking is enabled
         if (setting('Auth.sessionConfig')['trackDeviceSessions'] ?? false) {
-            $sessionId = session_id();
-            if ($sessionId !== '' && $sessionId !== false) {
-                /** @var DeviceSessionModel $deviceSessionModel */
-                $deviceSessionModel = model(DeviceSessionModel::class);
-                $deviceSessionModel->terminateSession($sessionId);
-            }
+            $this->deviceRecorder->terminateCurrentSession();
         }
 
         // Destroy the session data - but ensure a session is still
@@ -478,31 +463,7 @@ class Session extends Base implements AuthenticatorInterface
      */
     private function getIdentitiesForAction(User $user): array
     {
-        return $this->userIdentityModel->getIdentitiesByTypes(
-            $user,
-            $this->getActionTypes(),
-        );
-    }
-
-    /**
-     * @return list<string>
-     */
-    private function getActionTypes(): array
-    {
-        $actions = setting('Auth.actions');
-        $types   = [];
-
-        foreach ($actions as $actionClass) {
-            if ($actionClass === null) {
-                continue;
-            }
-
-            /** @var ActionInterface $action */
-            $action  = Factories::actions($actionClass);  // @phpstan-ignore-line
-            $types[] = $action->getType();
-        }
-
-        return $types;
+        return $this->actionCoordinator->getIdentitiesForAction($user);
     }
 
     /**
@@ -572,7 +533,7 @@ class Session extends Base implements AuthenticatorInterface
         // We'll give a 20% chance to need to do a purge since we
         // don't need to purge THAT often, it's just a maintenance issue.
         // to keep the table from getting out of control.
-        if (random_int(1, 100) <= 20) {
+        if (random_int(1, 100) <= (int) setting('AuthSecurity.rememberMePurgeChance')) {
             $this->rememberMe->purgeOldTokens();
         }
     }
@@ -586,23 +547,10 @@ class Session extends Base implements AuthenticatorInterface
      */
     public function startUpAction(string $type, User $user): bool
     {
-        $actionClass = setting('Auth.actions')[$type] ?? null;
+        $activated = $this->actionCoordinator->activateAction($type, $user);
 
-        if ($actionClass === null) {
-            return false;
-        }
-
-        /** @var ActionInterface $action */
-        $action = Factories::actions($actionClass); // @phpstan-ignore-line
-
-        // Create identity for the action.
-        $secret = $action->createIdentity($user);
-
-        // An empty return value means the action decided to skip itself for this user
-        // (e.g. Totp2FA when the user has no TOTP configured).
-        // Clear any stale auth_action session key that setAuthAction() may have set
-        // earlier in login() from a leftover DB marker.
-        if ($secret === '') {
+        if (! $activated) {
+            // Action was skipped or not configured — clear any stale session state
             $this->removeSessionKey('auth_action');
             $this->removeSessionKey('auth_action_message');
 
@@ -688,29 +636,18 @@ class Session extends Base implements AuthenticatorInterface
             return false;
         }
 
-        $authActions = setting('Auth.actions');
+        $pending = $this->actionCoordinator->findPendingAction($this->user);
 
-        foreach ($authActions as $actionClass) {
-            if ($actionClass === null) {
-                continue;
-            }
-
-            /** @var ActionInterface $action */
-            $action = Factories::actions($actionClass);  // @phpstan-ignore-line
-
-            $identity = $this->userIdentityModel->getIdentityByType($this->user, $action->getType());
-
-            if ($identity instanceof UserIdentity) {
-                $this->userState = AuthenticationState::PENDING;
-
-                $this->setSessionKey('auth_action', $actionClass);
-                $this->setSessionKey('auth_action_message', $identity->extra);
-
-                return true;
-            }
+        if ($pending === null) {
+            return false;
         }
 
-        return false;
+        $this->userState = AuthenticationState::PENDING;
+
+        $this->setSessionKey('auth_action', $pending['actionClass']);
+        $this->setSessionKey('auth_action_message', $pending['message']);
+
+        return true;
     }
 
     /**
@@ -793,7 +730,7 @@ class Session extends Base implements AuthenticatorInterface
 
         // Track the device session if enabled
         if (setting('Auth.sessionConfig')['trackDeviceSessions'] ?? false) {
-            $this->recordDeviceSession($user);
+            $this->deviceRecorder->recordSession($user, $this->request->getIPAddress());
         }
 
         /** @var Response $response */
@@ -801,30 +738,6 @@ class Session extends Base implements AuthenticatorInterface
 
         // When logged in, ensure cache control headers are in place
         $response->noCache();
-    }
-
-    /**
-     * Creates a device session record for the given user.
-     */
-    private function recordDeviceSession(User $user): void
-    {
-        $sessionId = session_id();
-
-        // No active session (e.g. testing environment without a real session)
-        if ($sessionId === '' || $sessionId === false) {
-            return;
-        }
-
-        /** @var DeviceSessionModel $deviceSessionModel */
-        $deviceSessionModel = model(DeviceSessionModel::class);
-
-        $ipAddress = $this->request->getIPAddress();
-
-        /** @var IncomingRequest $incomingRequest */
-        $incomingRequest = service('request');
-        $userAgent       = (string) $incomingRequest->getUserAgent();
-
-        $deviceSessionModel->createSession($user, $sessionId, $ipAddress, $userAgent !== '' ? $userAgent : null);
     }
 
     /**

--- a/src/Authentication/Authenticators/StatelessAuthenticator.php
+++ b/src/Authentication/Authenticators/StatelessAuthenticator.php
@@ -22,6 +22,11 @@ use Daycry\Auth\Exceptions\AuthenticationException;
  * Provides shared login/logout/loggedIn/loginById logic.
  * Concrete classes must implement getTokenFromRequest() to extract
  * the raw credential from the current HTTP request.
+ *
+ * Note on memoization: loggedIn() short-circuits via `$this->user !== null`
+ * after the first successful attempt(). The token is only re-validated on
+ * the very first call per request. Subsequent calls within the same request
+ * return immediately without hitting the DB or JWT verification again.
  */
 abstract class StatelessAuthenticator extends Base
 {
@@ -49,8 +54,11 @@ abstract class StatelessAuthenticator extends Base
 
     /**
      * Checks if the user is currently logged in.
-     * Since stateless authenticators carry no session state,
-     * the token is re-validated on every request.
+     *
+     * On the first call per request, the token from the HTTP request is
+     * validated (DB lookup for AccessToken, signature check for JWT).
+     * Once a user is resolved, subsequent calls short-circuit via the
+     * in-memory `$this->user` reference — no repeated validation.
      */
     public function loggedIn(): bool
     {

--- a/src/Authentication/JWT/Adapters/DaycryJWTAdapter.php
+++ b/src/Authentication/JWT/Adapters/DaycryJWTAdapter.php
@@ -26,7 +26,7 @@ class DaycryJWTAdapter implements JWTAdapterInterface
     public function decode(string $encodedToken): mixed
     {
         try {
-            $jwt = new JWT();
+            $jwt = new JWT(config('JWT'));
             $jwt->setSplitData(false)->setParamData('data');
             $token = $jwt->decode($encodedToken);
 
@@ -41,7 +41,7 @@ class DaycryJWTAdapter implements JWTAdapterInterface
      */
     public function encode(mixed $payload): string
     {
-        $jwt = new JWT();
+        $jwt = new JWT(config('JWT'));
         $jwt->setSplitData(false)->setParamData('data');
 
         return $jwt->encode($payload);

--- a/src/Authentication/Passwords/DictionaryValidator.php
+++ b/src/Authentication/Passwords/DictionaryValidator.php
@@ -26,6 +26,14 @@ use Daycry\Auth\Result;
 class DictionaryValidator extends BaseValidator implements PasswordValidatorInterface
 {
     /**
+     * In-memory cache of dictionary words for O(1) lookups.
+     * Keys are the dictionary words, values are irrelevant (array_flip).
+     *
+     * @var array<string, int>|null
+     */
+    private static ?array $dictionary = null;
+
+    /**
      * Checks the password against the words in the file and returns false
      * if a match is found. Returns true if no match is found.
      * If true is returned the password will be passed to next validator.
@@ -33,26 +41,51 @@ class DictionaryValidator extends BaseValidator implements PasswordValidatorInte
      */
     public function check(string $password, ?User $user = null): Result
     {
-        // Loop over our file
-        $fp = fopen(__DIR__ . '/_dictionary.txt', 'rb');
-        if ($fp) {
-            while (($line = fgets($fp, 4096)) !== false) {
-                if ($password === trim($line)) {
-                    fclose($fp);
-
-                    return new Result([
-                        'success'   => false,
-                        'reason'    => lang('Auth.errorPasswordCommon'),
-                        'extraInfo' => lang('Auth.suggestPasswordCommon'),
-                    ]);
-                }
-            }
+        if (self::$dictionary === null) {
+            self::$dictionary = $this->loadDictionary();
         }
 
-        fclose($fp);
+        if (isset(self::$dictionary[$password])) {
+            return new Result([
+                'success'   => false,
+                'reason'    => lang('Auth.errorPasswordCommon'),
+                'extraInfo' => lang('Auth.suggestPasswordCommon'),
+            ]);
+        }
 
         return new Result([
             'success' => true,
         ]);
+    }
+
+    /**
+     * Loads the dictionary file into an associative array for O(1) lookups.
+     * Returns an empty array if the file cannot be opened.
+     *
+     * @return array<string, int>
+     */
+    private function loadDictionary(): array
+    {
+        $fp = fopen(__DIR__ . '/_dictionary.txt', 'rb');
+
+        if ($fp === false) {
+            return [];
+        }
+
+        try {
+            $words = [];
+
+            while (($line = fgets($fp, 4096)) !== false) {
+                $word = trim($line);
+
+                if ($word !== '') {
+                    $words[] = $word;
+                }
+            }
+
+            return array_flip($words);
+        } finally {
+            fclose($fp);
+        }
     }
 }

--- a/src/Authentication/Passwords/PwnedValidator.php
+++ b/src/Authentication/Passwords/PwnedValidator.php
@@ -50,7 +50,7 @@ class PwnedValidator extends BaseValidator implements PasswordValidatorInterface
 
         try {
             $client = Services::curlrequest([
-                'base_uri' => 'https://api.pwnedpasswords.com/',
+                'base_uri' => setting('AuthSecurity.pwnedPasswordsApiUrl'),
             ]);
 
             $response = $client->get(

--- a/src/Authentication/Services/DeviceSessionRecorder.php
+++ b/src/Authentication/Services/DeviceSessionRecorder.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Daycry\Auth\Authentication\Services;
+
+use CodeIgniter\HTTP\IncomingRequest;
+use Daycry\Auth\Entities\User;
+use Daycry\Auth\Models\DeviceSessionModel;
+
+/**
+ * Handles creation and termination of device session records.
+ *
+ * Extracted from Session authenticator to isolate device-tracking
+ * concerns from the core authentication flow.
+ */
+class DeviceSessionRecorder
+{
+    /**
+     * Creates a device session record for the given user.
+     *
+     * Silently returns if there is no active PHP session (e.g. in testing).
+     */
+    public function recordSession(User $user, string $ipAddress): void
+    {
+        $sessionId = session_id();
+
+        // No active session (e.g. testing environment without a real session)
+        if ($sessionId === '' || $sessionId === false) {
+            return;
+        }
+
+        /** @var DeviceSessionModel $deviceSessionModel */
+        $deviceSessionModel = model(DeviceSessionModel::class);
+
+        /** @var IncomingRequest $incomingRequest */
+        $incomingRequest = service('request');
+        $userAgent       = (string) $incomingRequest->getUserAgent();
+
+        $deviceSessionModel->createSession($user, $sessionId, $ipAddress, $userAgent !== '' ? $userAgent : null);
+    }
+
+    /**
+     * Terminates the current device session.
+     */
+    public function terminateCurrentSession(): void
+    {
+        $sessionId = session_id();
+
+        if ($sessionId === '' || $sessionId === false) {
+            return;
+        }
+
+        /** @var DeviceSessionModel $deviceSessionModel */
+        $deviceSessionModel = model(DeviceSessionModel::class);
+        $deviceSessionModel->terminateSession($sessionId);
+    }
+}

--- a/src/Authentication/Services/PendingActionCoordinator.php
+++ b/src/Authentication/Services/PendingActionCoordinator.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Daycry\Auth\Authentication\Services;
+
+use CodeIgniter\Config\Factories;
+use Daycry\Auth\Entities\User;
+use Daycry\Auth\Entities\UserIdentity;
+use Daycry\Auth\Interfaces\ActionInterface;
+use Daycry\Auth\Models\UserIdentityModel;
+
+/**
+ * Coordinates post-authentication actions (Email2FA, EmailActivator, Totp2FA).
+ *
+ * Determines which action (if any) a user needs to complete after login
+ * and creates the necessary identity records. Session state mutation is
+ * left to the caller (Session authenticator).
+ */
+class PendingActionCoordinator
+{
+    public function __construct(
+        private readonly UserIdentityModel $identityModel,
+    ) {
+    }
+
+    /**
+     * Returns all identity types associated with configured auth actions.
+     *
+     * @return list<string>
+     */
+    public function getActionTypes(): array
+    {
+        $actions = setting('Auth.actions');
+        $types   = [];
+
+        foreach ($actions as $actionClass) {
+            if ($actionClass === null) {
+                continue;
+            }
+
+            /** @var ActionInterface $action */
+            $action  = Factories::actions($actionClass); // @phpstan-ignore-line
+            $types[] = $action->getType();
+        }
+
+        return $types;
+    }
+
+    /**
+     * Gets identities for configured auth actions.
+     *
+     * @return list<UserIdentity>
+     */
+    public function getIdentitiesForAction(User $user): array
+    {
+        return $this->identityModel->getIdentitiesByTypes(
+            $user,
+            $this->getActionTypes(),
+        );
+    }
+
+    /**
+     * Finds the first pending action identity for the user.
+     *
+     * Returns an array with the action class and identity extra data
+     * if a pending action is found, or null if none exists.
+     *
+     * @return array{actionClass: class-string<ActionInterface>, message: string|null}|null
+     */
+    public function findPendingAction(User $user): ?array
+    {
+        $authActions = setting('Auth.actions');
+
+        foreach ($authActions as $actionClass) {
+            if ($actionClass === null) {
+                continue;
+            }
+
+            /** @var ActionInterface $action */
+            $action = Factories::actions($actionClass); // @phpstan-ignore-line
+
+            $identity = $this->identityModel->getIdentityByType($user, $action->getType());
+
+            if ($identity instanceof UserIdentity) {
+                return [
+                    'actionClass' => $actionClass,
+                    'message'     => $identity->extra,
+                ];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Creates identity for the given action type if configured.
+     *
+     * Returns true if an action was activated, false if skipped or not configured.
+     *
+     * @param string $type 'register' or 'login'
+     */
+    public function activateAction(string $type, User $user): bool
+    {
+        $actionClass = setting('Auth.actions')[$type] ?? null;
+
+        if ($actionClass === null) {
+            return false;
+        }
+
+        /** @var ActionInterface $action */
+        $action = Factories::actions($actionClass); // @phpstan-ignore-line
+
+        // Create identity for the action
+        $secret = $action->createIdentity($user);
+
+        // Empty return means the action decided to skip itself
+        return $secret !== '';
+    }
+}

--- a/src/Authentication/Services/UserLockoutManager.php
+++ b/src/Authentication/Services/UserLockoutManager.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Daycry\Auth\Authentication\Services;
+
+use CodeIgniter\I18n\Time;
+use Daycry\Auth\Entities\User;
+use Daycry\Auth\Interfaces\UserProviderInterface;
+use Daycry\Auth\Result;
+
+/**
+ * Manages per-user account lockout after repeated failed login attempts.
+ *
+ * Extracted from Session authenticator to keep lockout logic in a single,
+ * testable place.
+ */
+class UserLockoutManager
+{
+    public function __construct(
+        private readonly UserProviderInterface $provider,
+    ) {
+    }
+
+    /**
+     * Checks whether the user account is currently locked.
+     *
+     * If the lockout has expired, the counter is reset automatically.
+     *
+     * @return Result|null A failure Result when locked, null when not locked.
+     */
+    public function isLockedOut(User $user): ?Result
+    {
+        $maxAttempts = (int) setting('AuthSecurity.userMaxAttempts');
+
+        if ($maxAttempts <= 0) {
+            return null;
+        }
+
+        if ($user->locked_until === null) {
+            return null;
+        }
+
+        $lockedUntil = Time::parse((string) $user->locked_until);
+
+        if ($lockedUntil->isAfter(Time::now())) {
+            $minutesLeft = (int) ceil(Time::now()->difference($lockedUntil)->getMinutes());
+
+            return new Result([
+                'success' => false,
+                'reason'  => lang('Auth.userLockedOut', [$minutesLeft]),
+            ]);
+        }
+
+        // Lockout has expired — reset counter automatically
+        $this->provider->update($user->id, ['failed_login_count' => 0, 'locked_until' => null]);
+
+        return null;
+    }
+
+    /**
+     * Records a failed login attempt for the given user.
+     *
+     * Increments the failure counter and locks the account when the
+     * configured threshold is reached.
+     */
+    public function recordFailedAttempt(User $user): void
+    {
+        $maxAttempts = (int) setting('AuthSecurity.userMaxAttempts');
+
+        if ($maxAttempts <= 0) {
+            return;
+        }
+
+        $count = ((int) ($user->failed_login_count ?? 0)) + 1;
+        $data  = ['failed_login_count' => $count];
+
+        if ($count >= $maxAttempts) {
+            $data['locked_until'] = Time::now()
+                ->addSeconds((int) setting('AuthSecurity.userLockoutTime'))
+                ->format('Y-m-d H:i:s');
+        }
+
+        $this->provider->update($user->id, $data);
+    }
+
+    /**
+     * Resets the failed-login counter on successful authentication.
+     */
+    public function resetOnSuccess(User $user): void
+    {
+        $maxAttempts = (int) setting('AuthSecurity.userMaxAttempts');
+
+        if ($maxAttempts <= 0) {
+            return;
+        }
+
+        if (((int) ($user->failed_login_count ?? 0)) > 0 || $user->locked_until !== null) {
+            $this->provider->update($user->id, ['failed_login_count' => 0, 'locked_until' => null]);
+        }
+    }
+}

--- a/src/Config/Auth.php
+++ b/src/Config/Auth.php
@@ -299,8 +299,20 @@ class Auth extends BaseConfig
 
     /**
      * --------------------------------------------------------------------
-     * View files
+     * Views used by Auth Controllers
      * --------------------------------------------------------------------
+     * Specify the views used by each auth controller.
+     *
+     * @var array<string, string> Expected keys:
+     *                            'login', 'register', 'layout',
+     *                            'action_email_2fa', 'action_email_2fa_verify', 'action_email_2fa_email',
+     *                            'action_totp_2fa_verify', 'action_totp_setup_show', 'action_totp_setup_success',
+     *                            'action_email_activate_show', 'action_email_activate_email',
+     *                            'magic-link-login', 'magic-link-message', 'magic-link-email',
+     *                            'password-reset-request', 'password-reset-message', 'password-reset-form', 'password-reset-email',
+     *                            'force-password-reset',
+     *                            'email-change-email',
+     *                            'security_overview'
      */
     public array $views = [
         'login'                       => '\Daycry\Auth\Views\login',

--- a/src/Config/AuthOAuth.php
+++ b/src/Config/AuthOAuth.php
@@ -47,6 +47,7 @@ class AuthOAuth extends BaseConfig
             'scopes'                 => ['openid', 'profile', 'email', 'offline_access', 'User.Read'],
             'defaultEndPointVersion' => '2.0',
             'tenant'                 => 'common', // 'common' | 'organizations' | <tenantId>
+            // 'fields'              => ['department', 'jobTitle', 'officeLocation', 'mobilePhone'],
         ],
 
         // ----------------------------------------------------------------
@@ -89,6 +90,9 @@ class AuthOAuth extends BaseConfig
         //     'urlAuthorize'            => 'https://provider.example.com/oauth/authorize',
         //     'urlAccessToken'          => 'https://provider.example.com/oauth/token',
         //     'urlResourceOwnerDetails' => 'https://provider.example.com/api/user',
+        //     'fields'                  => ['role', 'team'],
+        //     'fieldsEndpoint'          => 'https://api.example.com/userinfo',
+        //     'profileResolver'         => App\OAuth\MyCustomResolver::class,
         // ],
     ];
 }

--- a/src/Config/AuthSecurity.php
+++ b/src/Config/AuthSecurity.php
@@ -282,4 +282,21 @@ class AuthSecurity extends BaseConfig
     public bool $permissionCacheEnabled = false;
 
     public int $permissionCacheTTL = 300;
+
+    /**
+     * --------------------------------------------------------------------
+     * Remember-Me Purge Chance
+     * --------------------------------------------------------------------
+     * Probability (1–100) that old remember-me tokens are purged on login.
+     * Higher values mean more frequent purging. 0 = never purge automatically.
+     */
+    public int $rememberMePurgeChance = 20;
+
+    /**
+     * --------------------------------------------------------------------
+     * Pwned Passwords API URL
+     * --------------------------------------------------------------------
+     * Base URI for the Have I Been Pwned passwords range API.
+     */
+    public string $pwnedPasswordsApiUrl = 'https://api.pwnedpasswords.com/';
 }

--- a/src/Controllers/BaseAuthController.php
+++ b/src/Controllers/BaseAuthController.php
@@ -17,6 +17,7 @@ use App\Controllers\BaseController;
 use CodeIgniter\HTTP\RedirectResponse;
 use Daycry\Auth\Authentication\Authenticators\Session;
 use Daycry\Auth\Interfaces\AuthController;
+use Daycry\Auth\Models\LoginModel;
 use Daycry\Auth\Result;
 use Daycry\Auth\Traits\BaseControllerTrait;
 use Daycry\Auth\Traits\Viewable;
@@ -170,5 +171,32 @@ abstract class BaseAuthController extends BaseController implements AuthControll
         return $this->handleSuccess(
             config('Auth')->loginRedirect(),
         )->withCookies();
+    }
+
+    /**
+     * Records a login/action attempt in the login log.
+     *
+     * @param string          $type       Identity type (e.g. Session::ID_TYPE_MAGIC_LINK)
+     * @param string          $identifier The identifier used (email, token, etc.)
+     * @param bool            $success    Whether the attempt was successful
+     * @param int|string|null $userId     The user ID if known
+     */
+    protected function recordLoginAttempt(
+        string $type,
+        string $identifier,
+        bool $success,
+        $userId = null,
+    ): void {
+        /** @var LoginModel $loginModel */
+        $loginModel = model(LoginModel::class);
+
+        $loginModel->recordLoginAttempt(
+            $type,
+            $identifier,
+            $success,
+            $this->request->getIPAddress(),
+            (string) $this->request->getUserAgent(),
+            $userId,
+        );
     }
 }

--- a/src/Controllers/MagicLinkController.php
+++ b/src/Controllers/MagicLinkController.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
 namespace Daycry\Auth\Controllers;
 
 use CodeIgniter\Events\Events;
-use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\Exceptions\RuntimeException;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\I18n\Time;
 use Daycry\Auth\Authentication\Authenticators\Session;
-use Daycry\Auth\Models\LoginModel;
+use Daycry\Auth\Libraries\TokenEmailSender;
 use Daycry\Auth\Models\UserIdentityModel;
 use Daycry\Auth\Models\UserModel;
 
@@ -98,50 +98,19 @@ class MagicLinkController extends BaseAuthController
             return $this->handleError('magic-link', lang('Auth.invalidEmail'));
         }
 
-        /** @var UserIdentityModel $identityModel */
-        $identityModel = model(UserIdentityModel::class);
+        $sender = new TokenEmailSender();
 
-        // Delete any previous magic-link identities
-        $identityModel->deleteIdentitiesByType($user, Session::ID_TYPE_MAGIC_LINK);
-
-        // Generate the code and save it as an identity
-        helper('text');
-        $token = random_string('crypto', 20);
-
-        $identityModel->insert([
-            'user_id' => $user->id,
-            'type'    => Session::ID_TYPE_MAGIC_LINK,
-            'secret'  => $token,
-            'expires' => Time::now()->addSeconds(setting('AuthSecurity.magicLinkLifetime'))->format('Y-m-d H:i:s'),
-        ]);
-
-        /** @var IncomingRequest $request */
-        $request = service('request');
-
-        $ipAddress = $request->getIPAddress();
-        $userAgent = (string) $request->getUserAgent();
-        $date      = Time::now()->toDateTimeString();
-
-        // Send the user an email with the code
-        helper('email');
-        $email = emailer()->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
-        $email->setTo($user->email);
-        $email->setSubject(lang('Auth.magicLinkSubject'));
-        $email->setMessage($this->view(setting('Auth.views')['magic-link-email'], [
-            'token'     => $token,
-            'ipAddress' => $ipAddress,
-            'userAgent' => $userAgent,
-            'date'      => $date,
-        ]));
-
-        if ($email->send(false) === false) {
-            log_message('error', $email->printDebugger(['headers']));
-
+        try {
+            $sender->sendTokenEmail(
+                $user,
+                Session::ID_TYPE_MAGIC_LINK,
+                setting('AuthSecurity.magicLinkLifetime'),
+                lang('Auth.magicLinkSubject'),
+                setting('Auth.views')['magic-link-email'],
+            );
+        } catch (RuntimeException $e) {
             return $this->handleError('magic-link', lang('Auth.unableSendEmailToUser', [$user->email]));
         }
-
-        // Clear the email
-        $email->clear();
 
         // Redirect to message page instead of returning the view directly
         return redirect()->route('magic-link-message');
@@ -185,7 +154,7 @@ class MagicLinkController extends BaseAuthController
 
         // No token found?
         if ($identity === null) {
-            $this->recordLoginAttempt($identifier, false);
+            $this->recordLoginAttempt(Session::ID_TYPE_MAGIC_LINK, $identifier, false);
 
             $credentials = ['magicLinkToken' => $token];
             Events::trigger('failedLogin', $credentials);
@@ -198,7 +167,7 @@ class MagicLinkController extends BaseAuthController
 
         // Token expired?
         if (Time::now()->isAfter($identity->expires)) {
-            $this->recordLoginAttempt($identifier, false);
+            $this->recordLoginAttempt(Session::ID_TYPE_MAGIC_LINK, $identifier, false);
 
             $credentials = ['magicLinkToken' => $token];
             Events::trigger('failedLogin', $credentials);
@@ -219,7 +188,7 @@ class MagicLinkController extends BaseAuthController
 
         $user = $authenticator->getUser();
 
-        $this->recordLoginAttempt($identifier, true, $user->id);
+        $this->recordLoginAttempt(Session::ID_TYPE_MAGIC_LINK, $identifier, true, $user->id);
 
         // Give the developer a way to know the user
         // logged in via a magic link.
@@ -229,27 +198,6 @@ class MagicLinkController extends BaseAuthController
 
         // Get our login redirect url
         return redirect()->to(config('Auth')->loginRedirect());
-    }
-
-    /**
-     * @param int|string|null $userId
-     */
-    private function recordLoginAttempt(
-        string $identifier,
-        bool $success,
-        $userId = null,
-    ): void {
-        /** @var LoginModel $loginModel */
-        $loginModel = model(LoginModel::class);
-
-        $loginModel->recordLoginAttempt(
-            Session::ID_TYPE_MAGIC_LINK,
-            $identifier,
-            $success,
-            $this->request->getIPAddress(),
-            (string) $this->request->getUserAgent(),
-            $userId,
-        );
     }
 
     /**

--- a/src/Controllers/PasswordResetController.php
+++ b/src/Controllers/PasswordResetController.php
@@ -14,12 +14,12 @@ declare(strict_types=1);
 namespace Daycry\Auth\Controllers;
 
 use CodeIgniter\Events\Events;
-use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\Exceptions\RuntimeException;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\HTTP\ResponseInterface;
 use CodeIgniter\I18n\Time;
 use Daycry\Auth\Enums\IdentityType;
-use Daycry\Auth\Models\LoginModel;
+use Daycry\Auth\Libraries\TokenEmailSender;
 use Daycry\Auth\Models\UserIdentityModel;
 use Daycry\Auth\Models\UserModel;
 
@@ -75,55 +75,26 @@ class PasswordResetController extends BaseAuthController
         $user  = $this->provider->findByCredentials(['email' => $email]);
 
         if ($user !== null) {
-            /** @var UserIdentityModel $identityModel */
-            $identityModel = model(UserIdentityModel::class);
+            $sender = new TokenEmailSender();
 
-            // Delete any previous reset_password identities
-            $identityModel->deleteIdentitiesByType($user, IdentityType::RESET_PASSWORD->value);
-
-            // Generate the token and save it as an identity
-            helper('text');
-            $token = random_string('crypto', 20);
-
-            $identityModel->insert([
-                'user_id' => $user->id,
-                'type'    => IdentityType::RESET_PASSWORD->value,
-                'secret'  => $token,
-                'expires' => Time::now()->addSeconds(setting('AuthSecurity.passwordResetLifetime'))->format('Y-m-d H:i:s'),
-            ]);
-
-            /** @var IncomingRequest $request */
-            $request = service('request');
-
-            $ipAddress = $request->getIPAddress();
-            $userAgent = (string) $request->getUserAgent();
-            $date      = Time::now()->toDateTimeString();
-
-            // Send the user an email with the reset link
-            helper('email');
-            $emailService = emailer()->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
-            $emailService->setTo($user->email);
-            $emailService->setSubject(lang('Auth.passwordResetSubject'));
-            $emailService->setMessage($this->view(setting('Auth.views')['password-reset-email'], [
-                'token'     => $token,
-                'ipAddress' => $ipAddress,
-                'userAgent' => $userAgent,
-                'date'      => $date,
-                'user'      => $user,
-            ]));
-
-            if ($emailService->send(false) === false) {
-                log_message('error', $emailService->printDebugger(['headers']));
+            try {
+                $sender->sendTokenEmail(
+                    $user,
+                    IdentityType::RESET_PASSWORD->value,
+                    setting('AuthSecurity.passwordResetLifetime'),
+                    lang('Auth.passwordResetSubject'),
+                    setting('Auth.views')['password-reset-email'],
+                    ['user' => $user],
+                );
+            } catch (RuntimeException $e) {
+                log_message('error', $e->getMessage());
             }
 
-            // Clear the email
-            $emailService->clear();
-
             // Record the attempt
-            $this->recordAttempt($email, true, $user->id);
+            $this->recordLoginAttempt(IdentityType::RESET_PASSWORD->value, $email, true, $user->id);
         } else {
             // Record failed attempt but don't reveal that user doesn't exist
-            $this->recordAttempt($email, false);
+            $this->recordLoginAttempt(IdentityType::RESET_PASSWORD->value, $email, false);
         }
 
         // Always redirect to message view (don't reveal if user exists)
@@ -235,29 +206,6 @@ class PasswordResetController extends BaseAuthController
 
         return redirect()->route('login')
             ->with('message', lang('Auth.passwordResetSuccess'));
-    }
-
-    /**
-     * Records a login attempt for the password reset flow.
-     *
-     * @param int|string|null $userId
-     */
-    private function recordAttempt(
-        string $identifier,
-        bool $success,
-        $userId = null,
-    ): void {
-        /** @var LoginModel $loginModel */
-        $loginModel = model(LoginModel::class);
-
-        $loginModel->recordLoginAttempt(
-            IdentityType::RESET_PASSWORD->value,
-            $identifier,
-            $success,
-            $this->request->getIPAddress(),
-            (string) $this->request->getUserAgent(),
-            $userId,
-        );
     }
 
     /**

--- a/src/Enums/IdentityType.php
+++ b/src/Enums/IdentityType.php
@@ -27,4 +27,15 @@ enum IdentityType: string
     case RESET_PASSWORD = 'reset_password';
     case JWT_REFRESH    = 'jwt_refresh';
     case EMAIL_CHANGE   = 'email_change';
+
+    /**
+     * Build the identity type string for a dynamic OAuth provider.
+     *
+     * OAuth providers cannot be enum cases because the set is user-defined.
+     * This helper centralises the 'oauth_' prefix convention.
+     */
+    public static function oauthProvider(string $provider): string
+    {
+        return 'oauth_' . $provider;
+    }
 }

--- a/src/Libraries/Oauth/OauthManager.php
+++ b/src/Libraries/Oauth/OauthManager.php
@@ -13,12 +13,15 @@ declare(strict_types=1);
 
 namespace Daycry\Auth\Libraries\Oauth;
 
+use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\I18n\Time;
 use Daycry\Auth\Config\AuthOAuth as AuthConfig;
 use Daycry\Auth\Entities\User;
 use Daycry\Auth\Entities\UserIdentity;
 use Daycry\Auth\Exceptions\AuthenticationException;
+use Daycry\Auth\Libraries\Oauth\ProfileResolver\ProfileResolverFactory;
+use Daycry\Auth\Models\OAuthTokenRepository;
 use Daycry\Auth\Models\UserIdentityModel;
 use League\OAuth2\Client\Grant\RefreshToken;
 use League\OAuth2\Client\Provider\AbstractProvider;
@@ -31,12 +34,14 @@ use League\OAuth2\Client\Provider\ResourceOwnerInterface;
 use League\OAuth2\Client\Token\AccessTokenInterface;
 use TheNetworg\OAuth2\Client\Provider\Azure;
 use TheNetworg\OAuth2\Client\Provider\AzureResourceOwner;
+use Throwable;
 
 class OauthManager
 {
     protected AuthConfig $config;
     protected AbstractProvider $provider;
     protected string $providerName;
+    private ?OAuthTokenRepository $repository = null;
 
     /**
      * Map of provider alias → FQCN for well-known providers.
@@ -54,6 +59,25 @@ class OauthManager
     public function __construct(AuthConfig $config)
     {
         $this->config = $config;
+    }
+
+    /**
+     * Lazy-initialise the OAuth token repository.
+     */
+    private function getRepository(): OAuthTokenRepository
+    {
+        return $this->repository ??= new OAuthTokenRepository(
+            $this->getIdentityModel(),
+        );
+    }
+
+    /**
+     * Centralised model() call — avoids repeating it across methods.
+     */
+    private function getIdentityModel(): UserIdentityModel
+    {
+        /** @var UserIdentityModel */
+        return model(UserIdentityModel::class);
     }
 
     /**
@@ -101,35 +125,45 @@ class OauthManager
             throw new AuthenticationException(lang('Auth.unknownOauthProvider', [$this->providerName ?? 'null']));
         }
 
-        /** @var UserIdentityModel $identityModel */
-        $identityModel = model(UserIdentityModel::class);
+        $repo     = $this->getRepository();
+        $identity = $repo->findByUserAndProvider((int) $user->id, $this->providerName);
 
-        $type = 'oauth_' . $this->providerName;
+        if ($identity === null || empty($identity->extra)) {
+            return null;
+        }
 
-        /** @var UserIdentity|null $identity */
-        $identity = $identityModel->where('user_id', $user->id)
-            ->where('type', $type)
-            ->first();
+        $extraData    = $repo->parseExtra($identity->extra);
+        $refreshToken = $extraData['refresh_token'] ?? null;
 
-        if (! $identity || empty($identity->extra)) {
+        if (empty($refreshToken)) {
             return null;
         }
 
         try {
             $grant = new RefreshToken();
-            $token = $this->provider->getAccessToken($grant, ['refresh_token' => $identity->extra]);
+            $token = $this->provider->getAccessToken($grant, ['refresh_token' => $refreshToken]);
 
             $identity->secret2 = $token->getToken();
 
             if ($token->getRefreshToken()) {
-                $identity->extra = $token->getRefreshToken();
+                $extraData['refresh_token'] = $token->getRefreshToken();
             }
+
+            // Update scopes if the refreshed token includes them
+            $tokenValues = $token->getValues();
+            if (isset($tokenValues['scope'])) {
+                $extraData['scopes_granted'] = is_string($tokenValues['scope'])
+                    ? explode(' ', $tokenValues['scope'])
+                    : (array) $tokenValues['scope'];
+            }
+
+            $identity->extra = json_encode($extraData, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
 
             if ($token->getExpires()) {
                 $identity->expires = Time::createFromTimestamp($token->getExpires());
             }
 
-            $identityModel->save($identity);
+            $repo->updateOAuthIdentity($identity);
 
             return $token;
         } catch (IdentityProviderException) {
@@ -166,8 +200,17 @@ class OauthManager
         try {
             $token       = $this->provider->getAccessToken('authorization_code', ['code' => $code]);
             $userProfile = $this->provider->getResourceOwner($token);
+            $profileData = $this->fetchProfileFields($token, $userProfile);
 
-            return $this->processUser($userProfile, $token);
+            $user = $this->processUser($userProfile, $token, $profileData);
+
+            Events::trigger('oauth-login', $user, $this->providerName);
+
+            if ($profileData !== []) {
+                Events::trigger('oauth-profile-fetched', $user, $this->providerName, $profileData);
+            }
+
+            return $user;
         } catch (IdentityProviderException $e) {
             throw new AuthenticationException($e->getMessage());
         }
@@ -217,11 +260,12 @@ class OauthManager
 
     /**
      * Find or create a local user and OAuth identity for the resource owner.
+     *
+     * @param array<string, mixed> $profileData Extra profile fields from the resolver
      */
-    protected function processUser(ResourceOwnerInterface $userProfile, AccessTokenInterface $token): User
+    protected function processUser(ResourceOwnerInterface $userProfile, AccessTokenInterface $token, array $profileData = []): User
     {
-        /** @var UserIdentityModel $identityModel */
-        $identityModel = model(UserIdentityModel::class);
+        $repo = $this->getRepository();
 
         $data     = $this->extractUserData($userProfile);
         $socialId = $data['id'];
@@ -232,16 +276,40 @@ class OauthManager
             throw new AuthenticationException(lang('Auth.emailNotFoundInOauth'));
         }
 
-        $type     = 'oauth_' . $this->providerName;
-        $identity = $identityModel->where('type', $type)
-            ->where('secret', $socialId)
-            ->first();
+        $extraData = ['refresh_token' => $token->getRefreshToken()];
+
+        // Scopes (RFC 6749 §3.3: space-delimited)
+        $tokenValues = $token->getValues();
+        if (isset($tokenValues['scope'])) {
+            $extraData['scopes_granted'] = is_string($tokenValues['scope'])
+                ? explode(' ', $tokenValues['scope'])
+                : (array) $tokenValues['scope'];
+        }
+
+        if ($profileData !== []) {
+            $extraData['profile']            = $profileData;
+            $extraData['profile_fetched_at'] = Time::now()->toDateTimeString();
+        }
+
+        $extraJson = json_encode($extraData, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+
+        $identity = $repo->findByProviderAndSocialId($this->providerName, $socialId);
 
         $user = null;
 
         if ($identity) {
             /** @var UserIdentity $identity */
             $user = $identity->user();
+
+            // Update token and profile data on re-login
+            $identity->secret2 = $token->getToken();
+            $identity->extra   = $extraJson;
+
+            if ($token->getExpires()) {
+                $identity->expires = Time::createFromTimestamp($token->getExpires());
+            }
+
+            $repo->updateOAuthIdentity($identity);
         } else {
             $provider = auth()->getProvider();
             $user     = $provider->findByCredentials(['email' => $email]);
@@ -258,13 +326,11 @@ class OauthManager
                 $provider->addToDefaultGroup($user);
             }
 
-            $identityModel->insert([
-                'user_id' => $user->id,
-                'type'    => $type,
+            $repo->createOAuthIdentity((int) $user->id, $this->providerName, [
                 'name'    => $name ?? $email,
                 'secret'  => $socialId,
                 'secret2' => $token->getToken(),
-                'extra'   => $token->getRefreshToken(),
+                'extra'   => $extraJson,
                 'expires' => $token->getExpires() ? Time::createFromTimestamp($token->getExpires()) : null,
             ]);
         }
@@ -272,5 +338,39 @@ class OauthManager
         auth()->login($user);
 
         return $user;
+    }
+
+    /**
+     * Fetch additional profile fields using the appropriate resolver.
+     *
+     * @return array<string, mixed>
+     */
+    private function fetchProfileFields(AccessTokenInterface $token, ResourceOwnerInterface $resourceOwner): array
+    {
+        $providerConfig = $this->config->providers[$this->providerName] ?? [];
+        $fields         = $providerConfig['fields'] ?? [];
+
+        if ($fields === []) {
+            return [];
+        }
+
+        try {
+            return ProfileResolverFactory::create($this->providerName, $providerConfig)
+                ->fetchFields($this->provider, $token, $resourceOwner, $fields, $providerConfig);
+        } catch (Throwable $e) {
+            log_message('warning', 'OAuth profile fetch failed: ' . $e->getMessage());
+
+            return [];
+        }
+    }
+
+    /**
+     * Get the stored profile data for a user's OAuth identity.
+     *
+     * @return array<string, mixed>
+     */
+    public function getProfileData(User $user): array
+    {
+        return $this->getRepository()->getProfileData((int) $user->id, $this->providerName);
     }
 }

--- a/src/Libraries/Oauth/ProfileResolver/AzureProfileResolver.php
+++ b/src/Libraries/Oauth/ProfileResolver/AzureProfileResolver.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Daycry\Auth\Libraries\Oauth\ProfileResolver;
+
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use League\OAuth2\Client\Token\AccessTokenInterface;
+use TheNetworg\OAuth2\Client\Provider\Azure;
+
+class AzureProfileResolver implements ProfileResolverInterface
+{
+    /**
+     * Fetch fields from Microsoft Graph API.
+     *
+     * Uses the Azure provider's get() method which handles token refresh
+     * internally. Filters out @odata.* metadata keys from the response.
+     *
+     * @param list<string>         $fields
+     * @param array<string, mixed> $config
+     *
+     * @return array<string, mixed>
+     */
+    public function fetchFields(
+        AbstractProvider $provider,
+        AccessTokenInterface $token,
+        ResourceOwnerInterface $resourceOwner,
+        array $fields,
+        array $config = [],
+    ): array {
+        if (! $provider instanceof Azure) {
+            return [];
+        }
+
+        $select = implode(',', $fields);
+        $url    = 'https://graph.microsoft.com/v1.0/me?$select=' . $select;
+
+        /** @var array<string, mixed> $response */
+        $response = $provider->get($url, $token);
+
+        $result = [];
+
+        foreach ($response as $key => $value) {
+            // Skip OData metadata keys
+            if (str_starts_with($key, '@odata.')) {
+                continue;
+            }
+
+            if (in_array($key, $fields, true)) {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Libraries/Oauth/ProfileResolver/GenericProfileResolver.php
+++ b/src/Libraries/Oauth/ProfileResolver/GenericProfileResolver.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Daycry\Auth\Libraries\Oauth\ProfileResolver;
+
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use League\OAuth2\Client\Token\AccessTokenInterface;
+
+class GenericProfileResolver implements ProfileResolverInterface
+{
+    /**
+     * Fetch fields from a generic provider.
+     *
+     * If the provider config contains a 'fieldsEndpoint', performs an
+     * authenticated GET request to that URL. Otherwise, filters the
+     * resource owner's toArray() data to the requested fields.
+     *
+     * @param list<string>         $fields
+     * @param array<string, mixed> $config
+     *
+     * @return array<string, mixed>
+     */
+    public function fetchFields(
+        AbstractProvider $provider,
+        AccessTokenInterface $token,
+        ResourceOwnerInterface $resourceOwner,
+        array $fields,
+        array $config = [],
+    ): array {
+        $fieldsEndpoint = $config['fieldsEndpoint'] ?? null;
+
+        if (is_string($fieldsEndpoint) && $fieldsEndpoint !== '') {
+            return $this->fetchFromEndpoint($provider, $token, $fields, $fieldsEndpoint);
+        }
+
+        return $this->filterFromResourceOwner($resourceOwner, $fields);
+    }
+
+    /**
+     * Fetch fields from a custom endpoint using an authenticated request.
+     *
+     * @param list<string> $fields
+     *
+     * @return array<string, mixed>
+     */
+    private function fetchFromEndpoint(
+        AbstractProvider $provider,
+        AccessTokenInterface $token,
+        array $fields,
+        string $endpoint,
+    ): array {
+        $request  = $provider->getAuthenticatedRequest('GET', $endpoint, $token);
+        $response = $provider->getParsedResponse($request);
+
+        if (! is_array($response)) {
+            return [];
+        }
+
+        $result = [];
+
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $response)) {
+                $result[$field] = $response[$field];
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Filter the resource owner's data to the requested fields.
+     *
+     * @param list<string> $fields
+     *
+     * @return array<string, mixed>
+     */
+    private function filterFromResourceOwner(ResourceOwnerInterface $resourceOwner, array $fields): array
+    {
+        $data   = $resourceOwner->toArray();
+        $result = [];
+
+        foreach ($fields as $field) {
+            if (array_key_exists($field, $data)) {
+                $result[$field] = $data[$field];
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Libraries/Oauth/ProfileResolver/ProfileResolverFactory.php
+++ b/src/Libraries/Oauth/ProfileResolver/ProfileResolverFactory.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Daycry\Auth\Libraries\Oauth\ProfileResolver;
+
+use CodeIgniter\Exceptions\LogicException;
+
+class ProfileResolverFactory
+{
+    /**
+     * Map of provider alias to resolver class.
+     *
+     * @var array<string, class-string<ProfileResolverInterface>>
+     */
+    private static array $resolverMap = [
+        'azure' => AzureProfileResolver::class,
+    ];
+
+    /**
+     * Create the appropriate profile resolver for a provider.
+     *
+     * Resolution order:
+     *   1. $providerConfig['profileResolver'] (custom class — must implement ProfileResolverInterface)
+     *   2. Static map (azure → AzureProfileResolver)
+     *   3. Fallback → GenericProfileResolver
+     *
+     * @param array<string, mixed> $providerConfig Provider configuration from AuthOAuth
+     */
+    public static function create(string $providerName, array $providerConfig = []): ProfileResolverInterface
+    {
+        // 1. Config-based custom resolver
+        if (isset($providerConfig['profileResolver'])) {
+            $class = $providerConfig['profileResolver'];
+
+            if (! is_subclass_of($class, ProfileResolverInterface::class)) {
+                throw new LogicException(
+                    sprintf('Profile resolver "%s" must implement %s.', $class, ProfileResolverInterface::class),
+                );
+            }
+
+            return new $class();
+        }
+
+        // 2. Built-in map
+        $class = self::$resolverMap[$providerName] ?? GenericProfileResolver::class;
+
+        return new $class();
+    }
+}

--- a/src/Libraries/Oauth/ProfileResolver/ProfileResolverInterface.php
+++ b/src/Libraries/Oauth/ProfileResolver/ProfileResolverInterface.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Daycry\Auth\Libraries\Oauth\ProfileResolver;
+
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Provider\ResourceOwnerInterface;
+use League\OAuth2\Client\Token\AccessTokenInterface;
+
+interface ProfileResolverInterface
+{
+    /**
+     * Fetch additional profile fields from the provider's API.
+     *
+     * @param list<string>         $fields The field names to retrieve
+     * @param array<string, mixed> $config Provider configuration from AuthOAuth
+     *
+     * @return array<string, mixed> The resolved field values
+     */
+    public function fetchFields(
+        AbstractProvider $provider,
+        AccessTokenInterface $token,
+        ResourceOwnerInterface $resourceOwner,
+        array $fields,
+        array $config = [],
+    ): array;
+}

--- a/src/Libraries/TokenEmailSender.php
+++ b/src/Libraries/TokenEmailSender.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Daycry\Auth\Libraries;
+
+use CodeIgniter\Exceptions\RuntimeException;
+use CodeIgniter\HTTP\IncomingRequest;
+use CodeIgniter\I18n\Time;
+use Daycry\Auth\Entities\User;
+use Daycry\Auth\Models\UserIdentityModel;
+use Daycry\Auth\Traits\Viewable;
+
+/**
+ * Generates a cryptographic token, stores it as an identity, and sends
+ * an email with the token to the user.
+ *
+ * Shared by MagicLinkController and PasswordResetController.
+ */
+class TokenEmailSender
+{
+    use Viewable;
+
+    /**
+     * Generates a token identity and sends an email to the user.
+     *
+     * @param User                 $user          The user to send the email to
+     * @param string               $identityType  Identity type constant (e.g. Session::ID_TYPE_MAGIC_LINK)
+     * @param int                  $lifetime      Token lifetime in seconds
+     * @param string               $emailSubject  Email subject line (lang key already resolved)
+     * @param string               $emailView     View path for the email body
+     * @param array<string, mixed> $extraViewData Additional data passed to the email view
+     *
+     * @return string The generated raw token
+     *
+     * @throws RuntimeException When the email cannot be sent
+     */
+    public function sendTokenEmail(
+        User $user,
+        string $identityType,
+        int $lifetime,
+        string $emailSubject,
+        string $emailView,
+        array $extraViewData = [],
+    ): string {
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+
+        // Delete any previous identities of this type
+        $identityModel->deleteIdentitiesByType($user, $identityType);
+
+        // Generate the token and save it as an identity
+        helper('text');
+        $token = random_string('crypto', 20);
+
+        $identityModel->insert([
+            'user_id' => $user->id,
+            'type'    => $identityType,
+            'secret'  => $token,
+            'expires' => Time::now()->addSeconds($lifetime)->format('Y-m-d H:i:s'),
+        ]);
+
+        // Gather common email context
+        /** @var IncomingRequest $request */
+        $request   = service('request');
+        $ipAddress = $request->getIPAddress();
+        $userAgent = (string) $request->getUserAgent();
+        $date      = Time::now()->toDateTimeString();
+
+        // Build view data
+        $viewData = array_merge([
+            'token'     => $token,
+            'ipAddress' => $ipAddress,
+            'userAgent' => $userAgent,
+            'date'      => $date,
+        ], $extraViewData);
+
+        // Send the email
+        helper('email');
+        $email = emailer()->setFrom(setting('Email.fromEmail'), setting('Email.fromName') ?? '');
+        $email->setTo($user->email);
+        $email->setSubject($emailSubject);
+        $email->setMessage($this->view($emailView, $viewData));
+
+        if ($email->send(false) === false) {
+            log_message('error', $email->printDebugger(['headers']));
+
+            $email->clear();
+
+            throw new RuntimeException(
+                'Cannot send email for user: ' . $user->email,
+            );
+        }
+
+        $email->clear();
+
+        return $token;
+    }
+}

--- a/src/Models/AccessTokenRepository.php
+++ b/src/Models/AccessTokenRepository.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Daycry\Auth\Models;
+
+use Daycry\Auth\Authentication\Authenticators\AccessToken;
+use Daycry\Auth\Entities\AccessToken as AccessTokenIdentity;
+use Daycry\Auth\Entities\User;
+
+/**
+ * Repository for personal access token operations.
+ *
+ * Encapsulates all access token CRUD from UserIdentityModel
+ * into a focused, single-responsibility class.
+ */
+class AccessTokenRepository
+{
+    public function __construct(
+        private readonly UserIdentityModel $identityModel,
+    ) {
+    }
+
+    /**
+     * Generates a new personal access token for the user.
+     *
+     * @param string       $name   Token name
+     * @param list<string> $scopes Permissions the token grants
+     */
+    public function generateAccessToken(User $user, string $name, array $scopes = ['*']): AccessTokenIdentity
+    {
+        return $this->identityModel->generateAccessToken($user, $name, $scopes);
+    }
+
+    /**
+     * Finds an access token by its raw (unhashed) value.
+     * Excludes revoked tokens.
+     */
+    public function getAccessTokenByRawToken(string $rawToken): ?AccessTokenIdentity
+    {
+        return $this->identityModel->getAccessTokenByRawToken($rawToken);
+    }
+
+    /**
+     * Finds an access token for a specific user by raw token.
+     */
+    public function getAccessToken(User $user, string $rawToken): ?AccessTokenIdentity
+    {
+        return $this->identityModel->getAccessToken($user, $rawToken);
+    }
+
+    /**
+     * Given the ID, returns the given access token.
+     */
+    public function getAccessTokenById(int|string $id, User $user): ?AccessTokenIdentity
+    {
+        return $this->identityModel->getAccessTokenById($id, $user);
+    }
+
+    /**
+     * Returns all access tokens for a user.
+     *
+     * @return list<AccessTokenIdentity>
+     */
+    public function getAllAccessTokens(User $user): array
+    {
+        return $this->identityModel->getAllAccessToken($user);
+    }
+
+    /**
+     * Hard-deletes an access token by raw token value.
+     *
+     * @deprecated Use softRevokeAccessToken() for soft-revocation via revoked_at.
+     */
+    public function deleteAccessToken(User $user, string $rawToken): void
+    {
+        $this->identityModel->revokeAccessToken($user, $rawToken);
+    }
+
+    /**
+     * Hard-deletes an access token by its hashed secret.
+     *
+     * @deprecated Use softRevokeAccessTokenBySecret() for soft-revocation via revoked_at.
+     */
+    public function deleteAccessTokenBySecret(User $user, string $secretToken): void
+    {
+        $this->identityModel->revokeAccessTokenBySecret($user, $secretToken);
+    }
+
+    /**
+     * Hard-deletes all access tokens for a user.
+     *
+     * @deprecated Use softRevokeAllAccessTokens() for soft-revocation via revoked_at.
+     */
+    public function deleteAllAccessTokens(User $user): void
+    {
+        $this->identityModel->revokeAllAccessToken($user);
+    }
+
+    /**
+     * Soft-revokes an access token by setting revoked_at (by raw token).
+     */
+    public function softRevokeAccessToken(User $user, string $rawToken): void
+    {
+        $token = $this->identityModel->getAccessToken($user, $rawToken);
+
+        if ($token !== null) {
+            $this->identityModel->revokeIdentityById((int) $token->id);
+        }
+    }
+
+    /**
+     * Soft-revokes an access token by its hashed secret.
+     */
+    public function softRevokeAccessTokenBySecret(User $user, string $secretToken): void
+    {
+        $token = $this->identityModel
+            ->where('user_id', $user->id)
+            ->where('type', AccessToken::ID_TYPE_ACCESS_TOKEN)
+            ->where('secret', $secretToken)
+            ->asObject(AccessTokenIdentity::class)
+            ->first();
+
+        if ($token !== null) {
+            $this->identityModel->revokeIdentityById((int) $token->id);
+        }
+    }
+
+    /**
+     * Soft-revokes all access tokens for a user.
+     */
+    public function softRevokeAllAccessTokens(User $user): void
+    {
+        $this->identityModel->revokeIdentitiesByUserAndType(
+            (int) $user->id,
+            AccessToken::ID_TYPE_ACCESS_TOKEN,
+        );
+    }
+}

--- a/src/Models/JwtTokenRepository.php
+++ b/src/Models/JwtTokenRepository.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Daycry\Auth\Models;
+
+use Daycry\Auth\Entities\UserIdentity;
+
+/**
+ * Repository for JWT refresh token operations.
+ *
+ * Encapsulates JWT refresh token CRUD from UserIdentityModel.
+ */
+class JwtTokenRepository
+{
+    public function __construct(
+        private readonly UserIdentityModel $identityModel,
+    ) {
+    }
+
+    /**
+     * Stores a new JWT refresh token for the given user.
+     *
+     * @param int    $userId    User primary key
+     * @param string $rawToken  The raw (unhashed) token to store
+     * @param string $expiresAt Datetime string 'Y-m-d H:i:s'
+     */
+    public function createRefreshToken(int $userId, string $rawToken, string $expiresAt): void
+    {
+        $this->identityModel->createJwtRefreshToken($userId, $rawToken, $expiresAt);
+    }
+
+    /**
+     * Finds a valid (non-expired, non-revoked) JWT refresh token.
+     *
+     * @param int    $userId   User primary key
+     * @param string $rawToken The raw (unhashed) token
+     */
+    public function getRefreshToken(int $userId, string $rawToken): ?UserIdentity
+    {
+        return $this->identityModel->getJwtRefreshToken($userId, $rawToken);
+    }
+
+    /**
+     * Revokes a JWT refresh token (hard-delete).
+     *
+     * @param int $identityId The identity record primary key
+     */
+    public function revokeRefreshToken(int $identityId): void
+    {
+        $this->identityModel->delete($identityId);
+    }
+
+    /**
+     * Soft-revokes a JWT refresh token by setting revoked_at.
+     *
+     * @param int $identityId The identity record primary key
+     */
+    public function softRevokeRefreshToken(int $identityId): void
+    {
+        $this->identityModel->revokeIdentityById($identityId);
+    }
+}

--- a/src/Models/OAuthTokenRepository.php
+++ b/src/Models/OAuthTokenRepository.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Daycry\Auth\Models;
+
+use Daycry\Auth\Entities\UserIdentity;
+use Daycry\Auth\Enums\IdentityType;
+
+/**
+ * Repository for OAuth identity operations.
+ *
+ * Encapsulates all OAuth token/identity CRUD from UserIdentityModel
+ * into a focused, single-responsibility class.
+ */
+class OAuthTokenRepository
+{
+    public function __construct(
+        private readonly UserIdentityModel $identityModel,
+    ) {
+    }
+
+    /**
+     * Find an OAuth identity for a given user and provider.
+     */
+    public function findByUserAndProvider(int $userId, string $provider): ?UserIdentity
+    {
+        /** @var UserIdentity|null */
+        return $this->identityModel
+            ->where('user_id', $userId)
+            ->where('type', IdentityType::oauthProvider($provider))
+            ->first();
+    }
+
+    /**
+     * Find an OAuth identity by provider and social ID (the 'secret' column).
+     */
+    public function findByProviderAndSocialId(string $provider, string $socialId): ?UserIdentity
+    {
+        /** @var UserIdentity|null */
+        return $this->identityModel
+            ->where('type', IdentityType::oauthProvider($provider))
+            ->where('secret', $socialId)
+            ->first();
+    }
+
+    /**
+     * Create a new OAuth identity row.
+     *
+     * @param array<string, mixed> $data Must include: name, secret, secret2, extra, expires (nullable)
+     */
+    public function createOAuthIdentity(int $userId, string $provider, array $data): void
+    {
+        $this->identityModel->insert(array_merge($data, [
+            'user_id' => $userId,
+            'type'    => IdentityType::oauthProvider($provider),
+        ]));
+    }
+
+    /**
+     * Update an existing OAuth identity (token refresh, re-login, etc.).
+     */
+    public function updateOAuthIdentity(UserIdentity $identity): void
+    {
+        $this->identityModel->save($identity);
+    }
+
+    /**
+     * Get the stored profile data for a user's OAuth identity.
+     *
+     * @return array<string, mixed>
+     */
+    public function getProfileData(int $userId, string $provider): array
+    {
+        $identity = $this->findByUserAndProvider($userId, $provider);
+
+        if ($identity === null || empty($identity->extra)) {
+            return [];
+        }
+
+        $extraData = $this->parseExtra($identity->extra);
+
+        return $extraData['profile'] ?? [];
+    }
+
+    /**
+     * Parse the extra field from an OAuth identity.
+     *
+     * Handles backward compatibility: legacy format stored the refresh token
+     * as a plain string, new format uses JSON.
+     *
+     * @return array<string, mixed>
+     */
+    public function parseExtra(?string $extra): array
+    {
+        if ($extra === null || $extra === '') {
+            return [];
+        }
+
+        $decoded = json_decode($extra, true);
+
+        if (is_array($decoded) && json_last_error() === JSON_ERROR_NONE) {
+            return $decoded;
+        }
+
+        // Legacy: plain string is the refresh token
+        return ['refresh_token' => $extra];
+    }
+}

--- a/src/Models/UserIdentityModel.php
+++ b/src/Models/UserIdentityModel.php
@@ -149,6 +149,8 @@ class UserIdentityModel extends BaseModel
     /**
      * Generates a new personal access token for the user.
      *
+     * @deprecated Use AccessTokenRepository::generateAccessToken() instead.
+     *
      * @param string       $name   Token name
      * @param list<string> $scopes Permissions the token grants
      */
@@ -178,6 +180,9 @@ class UserIdentityModel extends BaseModel
         return $token;
     }
 
+    /**
+     * @deprecated Use AccessTokenRepository::getAccessTokenByRawToken() instead.
+     */
     public function getAccessTokenByRawToken(string $rawToken): ?AccessTokenIdentity
     {
         return $this
@@ -188,6 +193,9 @@ class UserIdentityModel extends BaseModel
             ->first();
     }
 
+    /**
+     * @deprecated Use AccessTokenRepository::getAccessToken() instead.
+     */
     public function getAccessToken(User $user, string $rawToken): ?AccessTokenIdentity
     {
         $this->checkUserId($user);
@@ -201,6 +209,8 @@ class UserIdentityModel extends BaseModel
 
     /**
      * Given the ID, returns the given access token.
+     *
+     * @deprecated Use AccessTokenRepository::getAccessTokenById() instead.
      *
      * @param int|string $id
      */
@@ -216,6 +226,8 @@ class UserIdentityModel extends BaseModel
     }
 
     /**
+     * @deprecated Use AccessTokenRepository::getAllAccessTokens() instead.
+     *
      * @return list<AccessTokenIdentity>
      */
     public function getAllAccessToken(User $user): array
@@ -325,6 +337,8 @@ class UserIdentityModel extends BaseModel
 
     /**
      * Delete any access tokens for the given raw token.
+     *
+     * @deprecated Use AccessTokenRepository::deleteAccessToken() or softRevokeAccessToken() instead.
      */
     public function revokeAccessToken(User $user, string $rawToken): void
     {
@@ -340,6 +354,8 @@ class UserIdentityModel extends BaseModel
 
     /**
      * Delete any access tokens for the given secret token.
+     *
+     * @deprecated Use AccessTokenRepository::deleteAccessTokenBySecret() or softRevokeAccessTokenBySecret() instead.
      */
     public function revokeAccessTokenBySecret(User $user, string $secretToken): void
     {
@@ -355,6 +371,8 @@ class UserIdentityModel extends BaseModel
 
     /**
      * Revokes all access tokens for this user.
+     *
+     * @deprecated Use AccessTokenRepository::deleteAllAccessTokens() or softRevokeAllAccessTokens() instead.
      */
     public function revokeAllAccessToken(User $user): void
     {
@@ -365,6 +383,18 @@ class UserIdentityModel extends BaseModel
             ->delete();
 
         $this->checkQueryReturn($return);
+    }
+
+    /**
+     * Soft-revoke all non-revoked identities for a user and type in a single UPDATE.
+     */
+    public function revokeIdentitiesByUserAndType(int $userId, string $type): void
+    {
+        $this->where('user_id', $userId)
+            ->where('type', $type)
+            ->where('revoked_at', null)
+            ->set('revoked_at', Time::now()->format('Y-m-d H:i:s'))
+            ->update();
     }
 
     /**
@@ -382,6 +412,8 @@ class UserIdentityModel extends BaseModel
      *
      * The raw token is hashed (SHA-256) before storage.
      *
+     * @deprecated Use JwtTokenRepository::createRefreshToken() instead.
+     *
      * @param int    $userId    User primary key
      * @param string $rawToken  The raw (unhashed) token to store
      * @param string $expiresAt Datetime string 'Y-m-d H:i:s'
@@ -398,6 +430,8 @@ class UserIdentityModel extends BaseModel
 
     /**
      * Finds a valid (non-expired, non-revoked) JWT refresh token.
+     *
+     * @deprecated Use JwtTokenRepository::getRefreshToken() instead.
      *
      * @param int    $userId   User primary key
      * @param string $rawToken The raw (unhashed) token

--- a/src/Traits/Authorizable.php
+++ b/src/Traits/Authorizable.php
@@ -31,6 +31,11 @@ trait Authorizable
     protected ?array $groups           = null;
     protected ?array $permissions      = null;
 
+    /**
+     * @var array<string, list<string>>|null Group name => list of permission names
+     */
+    protected ?array $groupPermissionsCache = null;
+
     private function groupModel(): GroupModel
     {
         /** @var GroupModel */
@@ -306,16 +311,7 @@ trait Authorizable
             }
 
             foreach ($this->groupCache as $groupName) {
-                // Look up group ID from the already-populated cache — avoids an N+1 DB query per group
-                $groupId = array_search($groupName, $this->groups, true);
-
-                if ($groupId === false) {
-                    continue;
-                }
-
-                $group            = new Group(['id' => $groupId, 'name' => $groupName]);
-                $groupPermissions = $this->getGroupPermissions($group);
-                $groupPermNames   = array_column($groupPermissions, 'name');
+                $groupPermNames = $this->groupPermissionsCache[$groupName] ?? [];
 
                 if (in_array('*', $groupPermNames, true)) {
                     return true;
@@ -424,24 +420,98 @@ trait Authorizable
     }
 
     /**
+     * Loads all permissions for all of the user's groups in two queries
+     * (one for permission_group rows, one for permission names) and
+     * populates $groupPermissionsCache. This eliminates the N+1 problem
+     * where can() previously called getGroupPermissions() per group.
+     */
+    private function eagerLoadGroupPermissions(): void
+    {
+        // Resolve group IDs from group names
+        $groupIds = [];
+
+        foreach ($this->groupCache as $groupName) {
+            $id = array_search($groupName, $this->groups, true);
+
+            if ($id !== false) {
+                $groupIds[] = $id;
+            }
+        }
+
+        if ($groupIds === []) {
+            return;
+        }
+
+        // Single query: get all permission_group rows for all user groups (respecting until_at)
+        $groupPermModel = $this->permissionGroupModel();
+        $now            = Time::now()->format('Y-m-d H:i:s');
+
+        $allGroupPerms = $groupPermModel
+            ->whereIn('group_id', $groupIds)
+            ->groupStart()
+            ->where('until_at')
+            ->orWhere('until_at >', $now)
+            ->groupEnd()
+            ->findAll();
+
+        // Build a map of group_id => [permission_id, ...] and collect all permission IDs
+        $permIds      = [];
+        $groupPermMap = [];
+
+        foreach ($allGroupPerms as $gp) {
+            $pid                  = (int) $gp->permission_id;
+            $gid                  = (int) $gp->group_id;
+            $permIds[]            = $pid;
+            $groupPermMap[$gid][] = $pid;
+        }
+
+        // Single query: get all permission names by IDs
+        $permNames = [];
+
+        if ($permIds !== []) {
+            $permModel = $this->permissionModel();
+            $perms     = $permModel->getByIds(array_unique($permIds));
+
+            foreach ($perms as $p) {
+                $permNames[(int) $p->id] = $p->name;
+            }
+        }
+
+        // Build the cache: groupName => [permissionName, ...]
+        foreach ($this->groupCache as $groupName) {
+            $gId                                     = array_search($groupName, $this->groups, true);
+            $this->groupPermissionsCache[$groupName] = [];
+
+            if ($gId !== false && isset($groupPermMap[(int) $gId])) {
+                foreach ($groupPermMap[(int) $gId] as $pid) {
+                    if (isset($permNames[$pid])) {
+                        $this->groupPermissionsCache[$groupName][] = $permNames[$pid];
+                    }
+                }
+            }
+        }
+    }
+
+    /**
      * Used internally to populate the User groups
      * so we hit the database as little as possible.
      * Reads from persistent cache when permissionCacheEnabled is true.
      */
     private function populateGroups(): void
     {
-        if (is_array($this->groupCache) && is_array($this->groups)) {
+        if (is_array($this->groupCache) && is_array($this->groups) && is_array($this->groupPermissionsCache)) {
             return;
         }
 
         // Try persistent cache first
         if (service('settings')->get('AuthSecurity.permissionCacheEnabled')) {
-            /** @var array{groups: array<int, string>, groupCache: list<string>}|null $cached */
+            /** @var array{groups: array<int, string>, groupCache: list<string>, groupPermissionsCache: array<string, list<string>>}|null $cached */
             $cached = cache($this->getPermissionCacheKey('groups'));
 
             if ($cached !== null) {
-                $this->groups     = $cached['groups'];
-                $this->groupCache = $cached['groupCache'];
+                $this->groups                = $cached['groups'];
+                $this->groupCache            = $cached['groupCache'];
+                $this->groupPermissionsCache = $cached['groupPermissionsCache'];
 
                 return;
             }
@@ -456,12 +526,20 @@ trait Authorizable
 
         $this->groupCache = array_column($this->getAllUserGroups(), 'name');
 
+        // Eager-load all group permissions in a single pass (eliminates N+1 queries in can())
+        $this->groupPermissionsCache = [];
+
+        if ($this->groupCache !== []) {
+            $this->eagerLoadGroupPermissions();
+        }
+
         // Store in persistent cache
         if (service('settings')->get('AuthSecurity.permissionCacheEnabled')) {
             $ttl = (int) (service('settings')->get('AuthSecurity.permissionCacheTTL') ?? 300);
             cache()->save($this->getPermissionCacheKey('groups'), [
-                'groups'     => $this->groups,
-                'groupCache' => $this->groupCache,
+                'groups'                => $this->groups,
+                'groupCache'            => $this->groupCache,
+                'groupPermissionsCache' => $this->groupPermissionsCache,
             ], $ttl);
         }
     }
@@ -527,6 +605,8 @@ trait Authorizable
     {
         cache()->delete($this->getPermissionCacheKey('groups'));
         cache()->delete($this->getPermissionCacheKey('permissions'));
+
+        $this->groupPermissionsCache = null;
     }
 
     /**
@@ -552,6 +632,9 @@ trait Authorizable
         if (service('settings')->get('AuthSecurity.permissionCacheEnabled')) {
             cache()->delete($this->getPermissionCacheKey('groups'));
         }
+
+        // Force re-population of group permissions on next access
+        $this->groupPermissionsCache = null;
     }
 
     /**

--- a/src/Traits/CheckQueryReturnTrait.php
+++ b/src/Traits/CheckQueryReturnTrait.php
@@ -87,10 +87,8 @@ trait CheckQueryReturnTrait
 
     protected function getPropertyDBDebug(): ReflectionProperty
     {
-        $refClass    = new ReflectionObject($this->db);
-        $refProperty = $refClass->getProperty('DBDebug');
-        $refProperty->setAccessible(true);
+        $refClass = new ReflectionObject($this->db);
 
-        return $refProperty;
+        return $refClass->getProperty('DBDebug');
     }
 }

--- a/tests/Authentication/Services/DeviceSessionRecorderTest.php
+++ b/tests/Authentication/Services/DeviceSessionRecorderTest.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Authentication\Services;
+
+use Daycry\Auth\Authentication\Services\DeviceSessionRecorder;
+use Daycry\Auth\Models\DeviceSessionModel;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\FakeUser;
+
+/**
+ * @internal
+ */
+final class DeviceSessionRecorderTest extends DatabaseTestCase
+{
+    use FakeUser;
+
+    private DeviceSessionRecorder $recorder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpFakeUser();
+
+        $this->recorder = new DeviceSessionRecorder();
+    }
+
+    public function testRecordSessionSkipsWithoutActiveSession(): void
+    {
+        // Without a real PHP session, session_id() returns '' — so no record is created
+        $this->recorder->recordSession($this->user, '127.0.0.1');
+
+        /** @var DeviceSessionModel $model */
+        $model = model(DeviceSessionModel::class);
+
+        $sessions = $model->getActiveForUser($this->user);
+        $this->assertCount(0, $sessions);
+    }
+
+    public function testTerminateCurrentSessionSkipsWithoutActiveSession(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        // Should not throw when there is no active PHP session
+        $this->recorder->terminateCurrentSession();
+    }
+
+    public function testRecordSessionCreatesRecord(): void
+    {
+        // Manually create a device session to test the model interaction
+        // (we can't start a real PHP session in PHPUnit)
+        /** @var DeviceSessionModel $model */
+        $model = model(DeviceSessionModel::class);
+
+        $session = $model->createSession($this->user, 'test-session-id', '192.168.1.1', 'PHPUnit Test Agent');
+
+        $this->assertSame((string) $this->user->id, (string) $session->user_id);
+        $this->assertSame('test-session-id', $session->session_id);
+        $this->assertSame('192.168.1.1', $session->ip_address);
+
+        // Verify it appears in active sessions
+        $active = $model->getActiveForUser($this->user);
+        $this->assertCount(1, $active);
+    }
+
+    public function testTerminateCurrentSessionDeletesRecord(): void
+    {
+        /** @var DeviceSessionModel $model */
+        $model = model(DeviceSessionModel::class);
+
+        // Create a session first
+        $model->createSession($this->user, 'terminate-test-session', '10.0.0.1', 'PHPUnit');
+
+        // Terminate it directly via model (since we can't set session_id())
+        $model->terminateSession('terminate-test-session');
+
+        $active = $model->getActiveForUser($this->user);
+        $this->assertCount(0, $active);
+    }
+}

--- a/tests/Authentication/Services/PendingActionCoordinatorTest.php
+++ b/tests/Authentication/Services/PendingActionCoordinatorTest.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Authentication\Services;
+
+use Daycry\Auth\Authentication\Actions\Email2FA;
+use Daycry\Auth\Authentication\Actions\EmailActivator;
+use Daycry\Auth\Authentication\Actions\Totp2FA;
+use Daycry\Auth\Authentication\Authenticators\Session;
+use Daycry\Auth\Authentication\Services\PendingActionCoordinator;
+use Daycry\Auth\Models\UserIdentityModel;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\FakeUser;
+
+/**
+ * @internal
+ */
+final class PendingActionCoordinatorTest extends DatabaseTestCase
+{
+    use FakeUser;
+
+    private PendingActionCoordinator $coordinator;
+    private UserIdentityModel $identityModel;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpFakeUser();
+
+        /** @var UserIdentityModel $identityModel */
+        $identityModel       = model(UserIdentityModel::class);
+        $this->identityModel = $identityModel;
+
+        $this->coordinator = new PendingActionCoordinator($identityModel);
+    }
+
+    public function testGetActionTypesReturnsConfiguredTypes(): void
+    {
+        $this->inkectMockAttributes([
+            'actions' => [
+                'register' => EmailActivator::class,
+                'login'    => Email2FA::class,
+            ],
+        ]);
+
+        $types = $this->coordinator->getActionTypes();
+
+        $this->assertCount(2, $types);
+        $this->assertContains(Session::ID_TYPE_EMAIL_ACTIVATE, $types);
+        $this->assertContains(Session::ID_TYPE_EMAIL_2FA, $types);
+    }
+
+    public function testGetActionTypesSkipsNull(): void
+    {
+        $this->inkectMockAttributes([
+            'actions' => [
+                'register' => null,
+                'login'    => Email2FA::class,
+            ],
+        ]);
+
+        $types = $this->coordinator->getActionTypes();
+
+        $this->assertCount(1, $types);
+        $this->assertContains(Session::ID_TYPE_EMAIL_2FA, $types);
+    }
+
+    public function testGetIdentitiesForActionReturnsMatchingIdentities(): void
+    {
+        $this->inkectMockAttributes([
+            'actions' => [
+                'register' => null,
+                'login'    => Email2FA::class,
+            ],
+        ]);
+
+        // Create an Email2FA identity
+        $this->identityModel->insert([
+            'user_id' => $this->user->id,
+            'type'    => Session::ID_TYPE_EMAIL_2FA,
+            'name'    => 'email2fa_pending',
+            'secret'  => '123456',
+            'extra'   => 'Please check your email.',
+        ]);
+
+        $identities = $this->coordinator->getIdentitiesForAction($this->user);
+
+        $this->assertCount(1, $identities);
+        $this->assertSame(Session::ID_TYPE_EMAIL_2FA, $identities[0]->type);
+    }
+
+    public function testFindPendingActionReturnsNullWhenNoPending(): void
+    {
+        $this->inkectMockAttributes([
+            'actions' => [
+                'register' => null,
+                'login'    => Email2FA::class,
+            ],
+        ]);
+
+        $result = $this->coordinator->findPendingAction($this->user);
+
+        $this->assertNull($result);
+    }
+
+    public function testFindPendingActionReturnsActionAndMessage(): void
+    {
+        $this->inkectMockAttributes([
+            'actions' => [
+                'register' => null,
+                'login'    => Email2FA::class,
+            ],
+        ]);
+
+        // Create a pending Email2FA identity
+        $this->identityModel->insert([
+            'user_id' => $this->user->id,
+            'type'    => Session::ID_TYPE_EMAIL_2FA,
+            'name'    => 'email2fa_pending',
+            'secret'  => '654321',
+            'extra'   => 'Check your email for the code.',
+        ]);
+
+        $result = $this->coordinator->findPendingAction($this->user);
+
+        $this->assertNotNull($result);
+        $this->assertSame(Email2FA::class, $result['actionClass']);
+        $this->assertSame('Check your email for the code.', $result['message']);
+    }
+
+    public function testActivateActionReturnsFalseWhenNotConfigured(): void
+    {
+        $this->inkectMockAttributes([
+            'actions' => [
+                'register' => null,
+                'login'    => null,
+            ],
+        ]);
+
+        $result = $this->coordinator->activateAction('login', $this->user);
+
+        $this->assertFalse($result);
+    }
+
+    public function testActivateActionReturnsTrueWhenActivated(): void
+    {
+        $this->inkectMockAttributes([
+            'actions' => [
+                'register' => null,
+                'login'    => Email2FA::class,
+            ],
+        ]);
+
+        $result = $this->coordinator->activateAction('login', $this->user);
+
+        $this->assertTrue($result);
+
+        // Verify identity was created
+        $identity = $this->identityModel->getIdentityByType($this->user, Session::ID_TYPE_EMAIL_2FA);
+        $this->assertNotNull($identity);
+    }
+
+    public function testActivateActionReturnsFalseWhenSkipped(): void
+    {
+        // Totp2FA skips when user has no TOTP secret confirmed
+        $this->inkectMockAttributes([
+            'actions' => [
+                'register' => null,
+                'login'    => Totp2FA::class,
+            ],
+        ]);
+
+        // User has no TOTP enabled, so action should skip
+        $result = $this->coordinator->activateAction('login', $this->user);
+
+        $this->assertFalse($result);
+    }
+}

--- a/tests/Authentication/Services/UserLockoutManagerTest.php
+++ b/tests/Authentication/Services/UserLockoutManagerTest.php
@@ -1,0 +1,172 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Authentication\Services;
+
+use CodeIgniter\I18n\Time;
+use Daycry\Auth\Authentication\Services\UserLockoutManager;
+use Daycry\Auth\Models\UserModel;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\FakeUser;
+
+/**
+ * @internal
+ */
+final class UserLockoutManagerTest extends DatabaseTestCase
+{
+    use FakeUser;
+
+    private UserLockoutManager $lockoutManager;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpFakeUser();
+
+        /** @var UserModel $provider */
+        $provider             = model(UserModel::class);
+        $this->lockoutManager = new UserLockoutManager($provider);
+    }
+
+    public function testIsLockedOutReturnsNullWhenDisabled(): void
+    {
+        $this->inkectMockAttributesSecurity(['userMaxAttempts' => 0]);
+
+        $result = $this->lockoutManager->isLockedOut($this->user);
+
+        $this->assertNull($result);
+    }
+
+    public function testIsLockedOutReturnsNullWhenNotLocked(): void
+    {
+        $this->inkectMockAttributesSecurity(['userMaxAttempts' => 5]);
+
+        $result = $this->lockoutManager->isLockedOut($this->user);
+
+        $this->assertNull($result);
+    }
+
+    public function testIsLockedOutReturnsResultWhenLocked(): void
+    {
+        $this->inkectMockAttributesSecurity(['userMaxAttempts' => 5]);
+
+        // Lock the user until 1 hour from now
+        $lockedUntil = Time::now()->addHours(1)->format('Y-m-d H:i:s');
+        model(UserModel::class)->update($this->user->id, [
+            'failed_login_count' => 5,
+            'locked_until'       => $lockedUntil,
+        ]);
+
+        // Refresh user entity
+        $this->user = model(UserModel::class)->find($this->user->id);
+
+        $result = $this->lockoutManager->isLockedOut($this->user);
+
+        $this->assertNotNull($result);
+        $this->assertFalse($result->isOK());
+    }
+
+    public function testIsLockedOutResetsExpiredLockout(): void
+    {
+        $this->inkectMockAttributesSecurity(['userMaxAttempts' => 5]);
+
+        // Lock the user until 1 hour ago (expired)
+        $lockedUntil = Time::now()->subHours(1)->format('Y-m-d H:i:s');
+        model(UserModel::class)->update($this->user->id, [
+            'failed_login_count' => 5,
+            'locked_until'       => $lockedUntil,
+        ]);
+
+        // Refresh user entity
+        $this->user = model(UserModel::class)->find($this->user->id);
+
+        $result = $this->lockoutManager->isLockedOut($this->user);
+
+        $this->assertNull($result);
+
+        // Verify counter was reset in DB
+        $freshUser = model(UserModel::class)->find($this->user->id);
+        $this->assertSame(0, (int) $freshUser->failed_login_count);
+        $this->assertNull($freshUser->locked_until);
+    }
+
+    public function testRecordFailedAttemptIncrementsCounter(): void
+    {
+        $this->inkectMockAttributesSecurity(['userMaxAttempts' => 5]);
+
+        $this->lockoutManager->recordFailedAttempt($this->user);
+
+        $freshUser = model(UserModel::class)->find($this->user->id);
+        $this->assertSame(1, (int) $freshUser->failed_login_count);
+        $this->assertNull($freshUser->locked_until);
+    }
+
+    public function testRecordFailedAttemptLocksAtThreshold(): void
+    {
+        $this->inkectMockAttributesSecurity([
+            'userMaxAttempts' => 3,
+            'userLockoutTime' => 600,
+        ]);
+
+        // Set counter just below threshold
+        model(UserModel::class)->update($this->user->id, [
+            'failed_login_count' => 2,
+        ]);
+        $this->user = model(UserModel::class)->find($this->user->id);
+
+        $this->lockoutManager->recordFailedAttempt($this->user);
+
+        $freshUser = model(UserModel::class)->find($this->user->id);
+        $this->assertSame(3, (int) $freshUser->failed_login_count);
+        $this->assertNotNull($freshUser->locked_until);
+    }
+
+    public function testRecordFailedAttemptNoOpWhenDisabled(): void
+    {
+        $this->inkectMockAttributesSecurity(['userMaxAttempts' => 0]);
+
+        $this->lockoutManager->recordFailedAttempt($this->user);
+
+        $freshUser = model(UserModel::class)->find($this->user->id);
+        $this->assertSame(0, (int) $freshUser->failed_login_count);
+    }
+
+    public function testResetOnSuccessClearsCounter(): void
+    {
+        $this->inkectMockAttributesSecurity(['userMaxAttempts' => 5]);
+
+        // Set a non-zero counter
+        model(UserModel::class)->update($this->user->id, [
+            'failed_login_count' => 3,
+        ]);
+        $this->user = model(UserModel::class)->find($this->user->id);
+
+        $this->lockoutManager->resetOnSuccess($this->user);
+
+        $freshUser = model(UserModel::class)->find($this->user->id);
+        $this->assertSame(0, (int) $freshUser->failed_login_count);
+        $this->assertNull($freshUser->locked_until);
+    }
+
+    public function testResetOnSuccessNoOpWhenAlreadyZero(): void
+    {
+        $this->inkectMockAttributesSecurity(['userMaxAttempts' => 5]);
+
+        // User already has 0 failed attempts — resetOnSuccess should not call update
+        $this->lockoutManager->resetOnSuccess($this->user);
+
+        $freshUser = model(UserModel::class)->find($this->user->id);
+        $this->assertSame(0, (int) $freshUser->failed_login_count);
+    }
+}

--- a/tests/Collectors/AuthCollectorTest.php
+++ b/tests/Collectors/AuthCollectorTest.php
@@ -43,19 +43,15 @@ final class AuthCollectorTest extends DatabaseTestCase
         $reflection = new ReflectionClass($this->collector);
 
         $hasTimeline = $reflection->getProperty('hasTimeline');
-        $hasTimeline->setAccessible(true);
         $this->assertFalse($hasTimeline->getValue($this->collector));
 
         $hasTabContent = $reflection->getProperty('hasTabContent');
-        $hasTabContent->setAccessible(true);
         $this->assertTrue($hasTabContent->getValue($this->collector));
 
         $hasVarData = $reflection->getProperty('hasVarData');
-        $hasVarData->setAccessible(true);
         $this->assertFalse($hasVarData->getValue($this->collector));
 
         $title = $reflection->getProperty('title');
-        $title->setAccessible(true);
         $this->assertSame('Auth', $title->getValue($this->collector));
     }
 

--- a/tests/Libraries/Oauth/ProfileResolver/AzureProfileResolverTest.php
+++ b/tests/Libraries/Oauth/ProfileResolver/AzureProfileResolverTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Libraries\Oauth\ProfileResolver;
+
+use Daycry\Auth\Libraries\Oauth\ProfileResolver\AzureProfileResolver;
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Provider\GenericResourceOwner;
+use League\OAuth2\Client\Token\AccessToken;
+use Mockery;
+use RuntimeException;
+use Tests\Support\TestCase;
+use TheNetworg\OAuth2\Client\Provider\Azure;
+
+/**
+ * @internal
+ */
+final class AzureProfileResolverTest extends TestCase
+{
+    private AzureProfileResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resolver = new AzureProfileResolver();
+    }
+
+    public function testFetchFieldsFromGraph(): void
+    {
+        $token         = new AccessToken(['access_token' => 'test_token']);
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+
+        $provider = Mockery::mock(Azure::class);
+        $provider->shouldReceive('get')
+            ->withArgs(static fn (string $url, $tkn) => str_contains($url, 'graph.microsoft.com/v1.0/me')
+                    && str_contains($url, '$select=department,jobTitle'))
+            ->andReturn([
+                '@odata.context' => 'https://graph.microsoft.com/v1.0/$metadata#users/$entity',
+                'department'     => 'Engineering',
+                'jobTitle'       => 'Developer',
+                'extraField'     => 'should_be_ignored',
+            ]);
+
+        $result = $this->resolver->fetchFields(
+            $provider,
+            $token,
+            $resourceOwner,
+            ['department', 'jobTitle'],
+        );
+
+        $this->assertSame(['department' => 'Engineering', 'jobTitle' => 'Developer'], $result);
+    }
+
+    public function testFiltersOdataKeys(): void
+    {
+        $token         = new AccessToken(['access_token' => 'test_token']);
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+
+        $provider = Mockery::mock(Azure::class);
+        $provider->shouldReceive('get')
+            ->andReturn([
+                '@odata.context'  => 'some_context',
+                '@odata.nextLink' => 'some_link',
+                'department'      => 'Sales',
+            ]);
+
+        $result = $this->resolver->fetchFields(
+            $provider,
+            $token,
+            $resourceOwner,
+            ['department'],
+        );
+
+        $this->assertArrayNotHasKey('@odata.context', $result);
+        $this->assertArrayNotHasKey('@odata.nextLink', $result);
+        $this->assertSame('Sales', $result['department']);
+    }
+
+    public function testReturnsEmptyForNonAzureProvider(): void
+    {
+        $token         = new AccessToken(['access_token' => 'test_token']);
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+        $provider      = Mockery::mock(AbstractProvider::class);
+
+        $result = $this->resolver->fetchFields(
+            $provider,
+            $token,
+            $resourceOwner,
+            ['department'],
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testReturnsEmptyWhenGraphFails(): void
+    {
+        $token         = new AccessToken(['access_token' => 'test_token']);
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+
+        $provider = Mockery::mock(Azure::class);
+        $provider->shouldReceive('get')
+            ->andThrow(new RuntimeException('Graph API error'));
+
+        $this->expectException(RuntimeException::class);
+
+        $this->resolver->fetchFields(
+            $provider,
+            $token,
+            $resourceOwner,
+            ['department'],
+        );
+    }
+}

--- a/tests/Libraries/Oauth/ProfileResolver/GenericProfileResolverTest.php
+++ b/tests/Libraries/Oauth/ProfileResolver/GenericProfileResolverTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Libraries\Oauth\ProfileResolver;
+
+use Daycry\Auth\Libraries\Oauth\ProfileResolver\GenericProfileResolver;
+use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Provider\GenericResourceOwner;
+use League\OAuth2\Client\Token\AccessToken;
+use Mockery;
+use Psr\Http\Message\RequestInterface;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class GenericProfileResolverTest extends TestCase
+{
+    private GenericProfileResolver $resolver;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->resolver = new GenericProfileResolver();
+    }
+
+    public function testFilterFromResourceOwner(): void
+    {
+        $token = new AccessToken(['access_token' => 'test_token']);
+
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+        $resourceOwner->shouldReceive('toArray')->andReturn([
+            'id'        => '123',
+            'email'     => 'user@example.com',
+            'name'      => 'Test User',
+            'role'      => 'admin',
+            'team'      => 'backend',
+            'unrelated' => 'value',
+        ]);
+
+        $provider = Mockery::mock(AbstractProvider::class);
+
+        $result = $this->resolver->fetchFields(
+            $provider,
+            $token,
+            $resourceOwner,
+            ['role', 'team'],
+        );
+
+        $this->assertSame(['role' => 'admin', 'team' => 'backend'], $result);
+    }
+
+    public function testFilterIgnoresMissingFields(): void
+    {
+        $token = new AccessToken(['access_token' => 'test_token']);
+
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+        $resourceOwner->shouldReceive('toArray')->andReturn([
+            'id'   => '123',
+            'role' => 'editor',
+        ]);
+
+        $provider = Mockery::mock(AbstractProvider::class);
+
+        $result = $this->resolver->fetchFields(
+            $provider,
+            $token,
+            $resourceOwner,
+            ['role', 'nonexistent'],
+        );
+
+        $this->assertSame(['role' => 'editor'], $result);
+    }
+
+    public function testFetchFromFieldsEndpoint(): void
+    {
+        $token         = new AccessToken(['access_token' => 'test_token']);
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+
+        $mockRequest = Mockery::mock(RequestInterface::class);
+
+        $provider = Mockery::mock(AbstractProvider::class);
+        $provider->shouldReceive('getAuthenticatedRequest')
+            ->with('GET', 'https://api.example.com/userinfo', $token)
+            ->andReturn($mockRequest);
+        $provider->shouldReceive('getParsedResponse')
+            ->with($mockRequest)
+            ->andReturn([
+                'role'      => 'manager',
+                'team'      => 'platform',
+                'unrelated' => 'ignored',
+            ]);
+
+        $result = $this->resolver->fetchFields(
+            $provider,
+            $token,
+            $resourceOwner,
+            ['role', 'team'],
+            ['fieldsEndpoint' => 'https://api.example.com/userinfo'],
+        );
+
+        $this->assertSame(['role' => 'manager', 'team' => 'platform'], $result);
+    }
+
+    public function testFieldsEndpointReturnsEmptyOnNonArrayResponse(): void
+    {
+        $token         = new AccessToken(['access_token' => 'test_token']);
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+
+        $mockRequest = Mockery::mock(RequestInterface::class);
+
+        $provider = Mockery::mock(AbstractProvider::class);
+        $provider->shouldReceive('getAuthenticatedRequest')->andReturn($mockRequest);
+        $provider->shouldReceive('getParsedResponse')->andReturn('not an array');
+
+        $result = $this->resolver->fetchFields(
+            $provider,
+            $token,
+            $resourceOwner,
+            ['role'],
+            ['fieldsEndpoint' => 'https://api.example.com/userinfo'],
+        );
+
+        $this->assertSame([], $result);
+    }
+
+    public function testEmptyFieldsEndpointFallsBackToResourceOwner(): void
+    {
+        $token = new AccessToken(['access_token' => 'test_token']);
+
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+        $resourceOwner->shouldReceive('toArray')->andReturn([
+            'role' => 'viewer',
+        ]);
+
+        $provider = Mockery::mock(AbstractProvider::class);
+
+        $result = $this->resolver->fetchFields(
+            $provider,
+            $token,
+            $resourceOwner,
+            ['role'],
+            ['fieldsEndpoint' => ''],
+        );
+
+        $this->assertSame(['role' => 'viewer'], $result);
+    }
+}

--- a/tests/Libraries/Oauth/ProfileResolver/ProfileResolverFactoryTest.php
+++ b/tests/Libraries/Oauth/ProfileResolver/ProfileResolverFactoryTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Libraries\Oauth\ProfileResolver;
+
+use CodeIgniter\Exceptions\LogicException;
+use Daycry\Auth\Libraries\Oauth\ProfileResolver\AzureProfileResolver;
+use Daycry\Auth\Libraries\Oauth\ProfileResolver\GenericProfileResolver;
+use Daycry\Auth\Libraries\Oauth\ProfileResolver\ProfileResolverFactory;
+use stdClass;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class ProfileResolverFactoryTest extends TestCase
+{
+    public function testCreateAzureResolver(): void
+    {
+        $resolver = ProfileResolverFactory::create('azure');
+
+        $this->assertInstanceOf(AzureProfileResolver::class, $resolver);
+    }
+
+    public function testCreateGenericFallback(): void
+    {
+        $resolver = ProfileResolverFactory::create('unknown_provider');
+
+        $this->assertInstanceOf(GenericProfileResolver::class, $resolver);
+    }
+
+    public function testCreateConfigBasedResolver(): void
+    {
+        // Config-based resolver takes priority over static map
+        $resolver = ProfileResolverFactory::create('azure', [
+            'profileResolver' => GenericProfileResolver::class,
+        ]);
+
+        $this->assertInstanceOf(GenericProfileResolver::class, $resolver);
+    }
+
+    public function testCreateInvalidResolverThrows(): void
+    {
+        $this->expectException(LogicException::class);
+
+        ProfileResolverFactory::create('test', [
+            'profileResolver' => stdClass::class,
+        ]);
+    }
+}

--- a/tests/Libraries/OauthManagerTest.php
+++ b/tests/Libraries/OauthManagerTest.php
@@ -13,14 +13,18 @@ declare(strict_types=1);
 
 namespace Tests\Libraries;
 
+use CodeIgniter\Events\Events;
 use CodeIgniter\HTTP\RedirectResponse;
 use CodeIgniter\Test\DatabaseTestTrait;
 use Daycry\Auth\Config\AuthOAuth as AuthConfig;
 use Daycry\Auth\Entities\User;
+use Daycry\Auth\Enums\IdentityType;
 use Daycry\Auth\Exceptions\AuthenticationException;
 use Daycry\Auth\Libraries\Oauth\OauthManager;
+use Daycry\Auth\Models\UserIdentityModel;
 use Daycry\Auth\Models\UserModel;
 use League\OAuth2\Client\Provider\AbstractProvider;
+use League\OAuth2\Client\Provider\Exception\IdentityProviderException;
 use League\OAuth2\Client\Provider\GenericResourceOwner;
 use League\OAuth2\Client\Token\AccessToken;
 use Mockery;
@@ -170,5 +174,557 @@ final class OauthManagerTest extends TestCase
             'type'    => 'oauth_generic',
             'secret'  => 'social_456',
         ]);
+    }
+
+    public function testHandleCallbackStoresJsonExtra(): void
+    {
+        session()->set('oauth2state', 'valid_state');
+
+        $provider    = Mockery::mock(AbstractProvider::class);
+        $accessToken = new AccessToken([
+            'access_token'  => 'test_token',
+            'refresh_token' => 'refresh_abc',
+        ]);
+
+        $provider->shouldReceive('getAccessToken')
+            ->with('authorization_code', ['code' => 'auth_code'])
+            ->andReturn($accessToken);
+
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+        $resourceOwner->shouldReceive('getId')->andReturn('social_json_1');
+        $resourceOwner->shouldReceive('toArray')->andReturn([
+            'email' => 'jsonuser@example.com',
+            'name'  => 'JsonUser',
+        ]);
+
+        $provider->shouldReceive('getResourceOwner')
+            ->with($accessToken)
+            ->andReturn($resourceOwner);
+
+        $this->manager->setProviderInstance($provider, 'generic');
+
+        $user = $this->manager->handleCallback('auth_code', 'valid_state');
+
+        // Verify extra is stored as JSON
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identity      = $identityModel->where('type', 'oauth_generic')
+            ->where('secret', 'social_json_1')
+            ->first();
+
+        $this->assertNotNull($identity);
+        $extra = json_decode($identity->extra, true);
+        $this->assertIsArray($extra);
+        $this->assertSame('refresh_abc', $extra['refresh_token']);
+    }
+
+    public function testHandleCallbackWithProfileFields(): void
+    {
+        // Configure fields for the generic provider
+        $config                                   = new AuthConfig();
+        $config->providers['generic_with_fields'] = [
+            'clientId'     => 'test',
+            'clientSecret' => 'test',
+            'redirectUri'  => 'http://localhost/callback',
+            'fields'       => ['role', 'team'],
+        ];
+
+        $manager = new OauthManager($config);
+
+        session()->set('oauth2state', 'valid_state');
+
+        $provider    = Mockery::mock(AbstractProvider::class);
+        $accessToken = new AccessToken([
+            'access_token'  => 'test_token',
+            'refresh_token' => 'refresh_xyz',
+        ]);
+
+        $provider->shouldReceive('getAccessToken')
+            ->with('authorization_code', ['code' => 'auth_code'])
+            ->andReturn($accessToken);
+
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+        $resourceOwner->shouldReceive('getId')->andReturn('social_profile_1');
+        $resourceOwner->shouldReceive('toArray')->andReturn([
+            'email' => 'profileuser@example.com',
+            'name'  => 'ProfileUser',
+            'role'  => 'admin',
+            'team'  => 'backend',
+            'other' => 'ignored',
+        ]);
+
+        $provider->shouldReceive('getResourceOwner')
+            ->with($accessToken)
+            ->andReturn($resourceOwner);
+
+        $manager->setProviderInstance($provider, 'generic_with_fields');
+
+        $user = $manager->handleCallback('auth_code', 'valid_state');
+
+        // Verify profile data is stored in extra JSON
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identity      = $identityModel->where('type', 'oauth_generic_with_fields')
+            ->where('secret', 'social_profile_1')
+            ->first();
+
+        $extra = json_decode($identity->extra, true);
+        $this->assertSame('refresh_xyz', $extra['refresh_token']);
+        $this->assertSame(['role' => 'admin', 'team' => 'backend'], $extra['profile']);
+    }
+
+    public function testHandleCallbackWorksWhenProfileFetchFails(): void
+    {
+        // Configure fields that won't be resolvable (but the resolver is generic,
+        // so it will just filter toArray - we test that the flow doesn't break)
+        session()->set('oauth2state', 'valid_state');
+
+        $provider    = Mockery::mock(AbstractProvider::class);
+        $accessToken = new AccessToken(['access_token' => 'test_token']);
+
+        $provider->shouldReceive('getAccessToken')
+            ->with('authorization_code', ['code' => 'auth_code'])
+            ->andReturn($accessToken);
+
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+        $resourceOwner->shouldReceive('getId')->andReturn('social_fail_1');
+        $resourceOwner->shouldReceive('toArray')->andReturn([
+            'email' => 'failuser@example.com',
+            'name'  => 'FailUser',
+        ]);
+
+        $provider->shouldReceive('getResourceOwner')
+            ->with($accessToken)
+            ->andReturn($resourceOwner);
+
+        $this->manager->setProviderInstance($provider, 'generic');
+
+        // Should succeed even without profile fields
+        $user = $this->manager->handleCallback('auth_code', 'valid_state');
+        $this->assertInstanceOf(User::class, $user);
+    }
+
+    public function testGetProfileDataReturnsStoredFields(): void
+    {
+        // Create user with OAuth identity containing profile data
+        $userModel = new UserModel();
+        $user      = new User([
+            'username' => 'ProfileDataUser',
+            'email'    => 'profiledata@example.com',
+            'password' => 'password123',
+        ]);
+        $userModel->save($user);
+        $user = $userModel->findById($userModel->getInsertID());
+
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identityModel->insert([
+            'user_id' => $user->id,
+            'type'    => 'oauth_generic',
+            'name'    => 'ProfileDataUser',
+            'secret'  => 'social_pd_1',
+            'secret2' => 'access_token_here',
+            'extra'   => json_encode([
+                'refresh_token' => 'rt_123',
+                'profile'       => ['role' => 'editor', 'team' => 'frontend'],
+            ]),
+        ]);
+
+        $provider = Mockery::mock(AbstractProvider::class);
+        $this->manager->setProviderInstance($provider, 'generic');
+
+        $profileData = $this->manager->getProfileData($user);
+
+        $this->assertSame(['role' => 'editor', 'team' => 'frontend'], $profileData);
+    }
+
+    public function testGetProfileDataReturnsEmptyForLegacyExtra(): void
+    {
+        $userModel = new UserModel();
+        $user      = new User([
+            'username' => 'LegacyUser',
+            'email'    => 'legacy@example.com',
+            'password' => 'password123',
+        ]);
+        $userModel->save($user);
+        $user = $userModel->findById($userModel->getInsertID());
+
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identityModel->insert([
+            'user_id' => $user->id,
+            'type'    => 'oauth_generic',
+            'name'    => 'LegacyUser',
+            'secret'  => 'social_legacy_1',
+            'secret2' => 'access_token_here',
+            'extra'   => 'plain_refresh_token_string',
+        ]);
+
+        $provider = Mockery::mock(AbstractProvider::class);
+        $this->manager->setProviderInstance($provider, 'generic');
+
+        $profileData = $this->manager->getProfileData($user);
+
+        $this->assertSame([], $profileData);
+    }
+
+    public function testReLoginUpdatesTokenAndProfile(): void
+    {
+        // Create user with existing OAuth identity
+        $userModel = new UserModel();
+        $user      = new User([
+            'username' => 'ReLoginUser',
+            'email'    => 'relogin@example.com',
+            'password' => 'password123',
+        ]);
+        $userModel->save($user);
+        $user = $userModel->findById($userModel->getInsertID());
+
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identityModel->insert([
+            'user_id' => $user->id,
+            'type'    => 'oauth_generic',
+            'name'    => 'ReLoginUser',
+            'secret'  => 'social_relogin_1',
+            'secret2' => 'old_access_token',
+            'extra'   => json_encode(['refresh_token' => 'old_refresh']),
+        ]);
+
+        session()->set('oauth2state', 'valid_state');
+
+        $provider    = Mockery::mock(AbstractProvider::class);
+        $accessToken = new AccessToken([
+            'access_token'  => 'new_access_token',
+            'refresh_token' => 'new_refresh_token',
+        ]);
+
+        $provider->shouldReceive('getAccessToken')
+            ->with('authorization_code', ['code' => 'auth_code'])
+            ->andReturn($accessToken);
+
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+        $resourceOwner->shouldReceive('getId')->andReturn('social_relogin_1');
+        $resourceOwner->shouldReceive('toArray')->andReturn([
+            'email' => 'relogin@example.com',
+            'name'  => 'ReLoginUser',
+        ]);
+
+        $provider->shouldReceive('getResourceOwner')
+            ->with($accessToken)
+            ->andReturn($resourceOwner);
+
+        $this->manager->setProviderInstance($provider, 'generic');
+
+        $returnedUser = $this->manager->handleCallback('auth_code', 'valid_state');
+
+        $this->assertSame($user->id, $returnedUser->id);
+
+        // Verify token was updated
+        $identity = $identityModel->where('type', 'oauth_generic')
+            ->where('secret', 'social_relogin_1')
+            ->first();
+
+        $this->assertSame('new_access_token', $identity->secret2);
+        $extra = json_decode($identity->extra, true);
+        $this->assertSame('new_refresh_token', $extra['refresh_token']);
+    }
+
+    public function testRefreshAccessTokenWithJsonExtra(): void
+    {
+        $userModel = new UserModel();
+        $user      = new User([
+            'username' => 'RefreshJsonUser',
+            'email'    => 'refreshjson@example.com',
+            'password' => 'password123',
+        ]);
+        $userModel->save($user);
+        $user = $userModel->findById($userModel->getInsertID());
+
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identityModel->insert([
+            'user_id' => $user->id,
+            'type'    => IdentityType::oauthProvider('generic'),
+            'name'    => 'RefreshJsonUser',
+            'secret'  => 'social_rj',
+            'secret2' => 'old_access',
+            'extra'   => json_encode(['refresh_token' => 'old_refresh', 'profile' => ['role' => 'admin']]),
+        ]);
+
+        $provider = Mockery::mock(AbstractProvider::class);
+        $newToken = new AccessToken([
+            'access_token'  => 'new_access',
+            'refresh_token' => 'new_refresh',
+        ]);
+        $provider->shouldReceive('getAccessToken')->andReturn($newToken);
+
+        $this->manager->setProviderInstance($provider, 'generic');
+
+        $result = $this->manager->refreshAccessToken($user);
+
+        $this->assertNotNull($result);
+        $this->assertSame('new_access', $result->getToken());
+
+        $identity = $identityModel->where('secret', 'social_rj')->first();
+        $extra    = json_decode($identity->extra, true);
+        $this->assertSame('new_refresh', $extra['refresh_token']);
+        $this->assertSame(['role' => 'admin'], $extra['profile']);
+    }
+
+    public function testRefreshAccessTokenWithLegacyExtra(): void
+    {
+        $userModel = new UserModel();
+        $user      = new User([
+            'username' => 'RefreshLegacyUser',
+            'email'    => 'refreshlegacy@example.com',
+            'password' => 'password123',
+        ]);
+        $userModel->save($user);
+        $user = $userModel->findById($userModel->getInsertID());
+
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identityModel->insert([
+            'user_id' => $user->id,
+            'type'    => IdentityType::oauthProvider('generic'),
+            'name'    => 'RefreshLegacyUser',
+            'secret'  => 'social_rl',
+            'secret2' => 'old_access',
+            'extra'   => 'plain_refresh_token',
+        ]);
+
+        $provider = Mockery::mock(AbstractProvider::class);
+        $newToken = new AccessToken([
+            'access_token'  => 'new_access',
+            'refresh_token' => 'new_refresh',
+        ]);
+        $provider->shouldReceive('getAccessToken')->andReturn($newToken);
+
+        $this->manager->setProviderInstance($provider, 'generic');
+
+        $result = $this->manager->refreshAccessToken($user);
+
+        $this->assertNotNull($result);
+        $this->assertSame('new_access', $result->getToken());
+    }
+
+    public function testRefreshAccessTokenNoIdentity(): void
+    {
+        $userModel = new UserModel();
+        $user      = new User([
+            'username' => 'NoIdentityUser',
+            'email'    => 'noidentity@example.com',
+            'password' => 'password123',
+        ]);
+        $userModel->save($user);
+        $user = $userModel->findById($userModel->getInsertID());
+
+        $provider = Mockery::mock(AbstractProvider::class);
+        $this->manager->setProviderInstance($provider, 'generic');
+
+        $result = $this->manager->refreshAccessToken($user);
+
+        $this->assertNull($result);
+    }
+
+    public function testRefreshAccessTokenProviderFails(): void
+    {
+        $userModel = new UserModel();
+        $user      = new User([
+            'username' => 'ProviderFailUser',
+            'email'    => 'providerfail@example.com',
+            'password' => 'password123',
+        ]);
+        $userModel->save($user);
+        $user = $userModel->findById($userModel->getInsertID());
+
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identityModel->insert([
+            'user_id' => $user->id,
+            'type'    => IdentityType::oauthProvider('generic'),
+            'name'    => 'ProviderFailUser',
+            'secret'  => 'social_pf',
+            'secret2' => 'old_access',
+            'extra'   => json_encode(['refresh_token' => 'some_refresh']),
+        ]);
+
+        $provider = Mockery::mock(AbstractProvider::class);
+        $provider->shouldReceive('getAccessToken')
+            ->andThrow(new IdentityProviderException('token expired', 0, []));
+
+        $this->manager->setProviderInstance($provider, 'generic');
+
+        $result = $this->manager->refreshAccessToken($user);
+
+        $this->assertNull($result);
+    }
+
+    public function testHandleCallbackTriggersOauthLoginEvent(): void
+    {
+        session()->set('oauth2state', 'valid_state');
+
+        $triggered = false;
+        Events::on('oauth-login', static function ($user, $providerName) use (&$triggered): void {
+            $triggered = true;
+        });
+
+        $provider    = Mockery::mock(AbstractProvider::class);
+        $accessToken = new AccessToken(['access_token' => 'test_token']);
+
+        $provider->shouldReceive('getAccessToken')
+            ->with('authorization_code', ['code' => 'auth_code'])
+            ->andReturn($accessToken);
+
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+        $resourceOwner->shouldReceive('getId')->andReturn('social_evt_1');
+        $resourceOwner->shouldReceive('toArray')->andReturn([
+            'email' => 'eventuser@example.com',
+            'name'  => 'EventUser',
+        ]);
+
+        $provider->shouldReceive('getResourceOwner')
+            ->with($accessToken)
+            ->andReturn($resourceOwner);
+
+        $this->manager->setProviderInstance($provider, 'generic');
+
+        $this->manager->handleCallback('auth_code', 'valid_state');
+
+        $this->assertTrue($triggered);
+    }
+
+    public function testHandleCallbackTriggersProfileFetchedEvent(): void
+    {
+        $config                                   = new AuthConfig();
+        $config->providers['generic_with_fields'] = [
+            'clientId'     => 'test',
+            'clientSecret' => 'test',
+            'redirectUri'  => 'http://localhost/callback',
+            'fields'       => ['role'],
+        ];
+
+        $manager = new OauthManager($config);
+
+        session()->set('oauth2state', 'valid_state');
+
+        $capturedData = [];
+        Events::on('oauth-profile-fetched', static function ($user, $provider, $profileData) use (&$capturedData): void {
+            $capturedData = $profileData;
+        });
+
+        $provider    = Mockery::mock(AbstractProvider::class);
+        $accessToken = new AccessToken(['access_token' => 'test_token']);
+
+        $provider->shouldReceive('getAccessToken')
+            ->with('authorization_code', ['code' => 'auth_code'])
+            ->andReturn($accessToken);
+
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+        $resourceOwner->shouldReceive('getId')->andReturn('social_pf_evt');
+        $resourceOwner->shouldReceive('toArray')->andReturn([
+            'email' => 'profileevt@example.com',
+            'name'  => 'ProfileEvtUser',
+            'role'  => 'editor',
+        ]);
+
+        $provider->shouldReceive('getResourceOwner')
+            ->with($accessToken)
+            ->andReturn($resourceOwner);
+
+        $manager->setProviderInstance($provider, 'generic_with_fields');
+
+        // Seed 'user' group (needed for new user creation)
+        $manager->handleCallback('auth_code', 'valid_state');
+
+        $this->assertSame(['role' => 'editor'], $capturedData);
+    }
+
+    public function testHandleCallbackStoresScopesGranted(): void
+    {
+        session()->set('oauth2state', 'valid_state');
+
+        $provider    = Mockery::mock(AbstractProvider::class);
+        $accessToken = new AccessToken([
+            'access_token' => 'test_token',
+            'scope'        => 'openid profile email',
+        ]);
+
+        $provider->shouldReceive('getAccessToken')
+            ->with('authorization_code', ['code' => 'auth_code'])
+            ->andReturn($accessToken);
+
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+        $resourceOwner->shouldReceive('getId')->andReturn('social_scope_1');
+        $resourceOwner->shouldReceive('toArray')->andReturn([
+            'email' => 'scopeuser@example.com',
+            'name'  => 'ScopeUser',
+        ]);
+
+        $provider->shouldReceive('getResourceOwner')
+            ->with($accessToken)
+            ->andReturn($resourceOwner);
+
+        $this->manager->setProviderInstance($provider, 'generic');
+
+        $this->manager->handleCallback('auth_code', 'valid_state');
+
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identity      = $identityModel->where('type', IdentityType::oauthProvider('generic'))
+            ->where('secret', 'social_scope_1')
+            ->first();
+
+        $extra = json_decode($identity->extra, true);
+        $this->assertSame(['openid', 'profile', 'email'], $extra['scopes_granted']);
+    }
+
+    public function testHandleCallbackStoresProfileFetchedAt(): void
+    {
+        $config                                   = new AuthConfig();
+        $config->providers['generic_with_fields'] = [
+            'clientId'     => 'test',
+            'clientSecret' => 'test',
+            'redirectUri'  => 'http://localhost/callback',
+            'fields'       => ['role'],
+        ];
+
+        $manager = new OauthManager($config);
+
+        session()->set('oauth2state', 'valid_state');
+
+        $provider    = Mockery::mock(AbstractProvider::class);
+        $accessToken = new AccessToken(['access_token' => 'test_token']);
+
+        $provider->shouldReceive('getAccessToken')
+            ->with('authorization_code', ['code' => 'auth_code'])
+            ->andReturn($accessToken);
+
+        $resourceOwner = Mockery::mock(GenericResourceOwner::class);
+        $resourceOwner->shouldReceive('getId')->andReturn('social_pfa_1');
+        $resourceOwner->shouldReceive('toArray')->andReturn([
+            'email' => 'pfauser@example.com',
+            'name'  => 'PfaUser',
+            'role'  => 'dev',
+        ]);
+
+        $provider->shouldReceive('getResourceOwner')
+            ->with($accessToken)
+            ->andReturn($resourceOwner);
+
+        $manager->setProviderInstance($provider, 'generic_with_fields');
+
+        $manager->handleCallback('auth_code', 'valid_state');
+
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identity      = $identityModel->where('type', IdentityType::oauthProvider('generic_with_fields'))
+            ->where('secret', 'social_pfa_1')
+            ->first();
+
+        $extra = json_decode($identity->extra, true);
+        $this->assertArrayHasKey('profile_fetched_at', $extra);
+        $this->assertNotEmpty($extra['profile_fetched_at']);
     }
 }

--- a/tests/Models/OAuthTokenRepositoryTest.php
+++ b/tests/Models/OAuthTokenRepositoryTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Models;
+
+use CodeIgniter\Test\DatabaseTestTrait;
+use Daycry\Auth\Entities\User;
+use Daycry\Auth\Enums\IdentityType;
+use Daycry\Auth\Models\OAuthTokenRepository;
+use Daycry\Auth\Models\UserIdentityModel;
+use Daycry\Auth\Models\UserModel;
+use Tests\Support\TestCase;
+
+/**
+ * @internal
+ */
+final class OAuthTokenRepositoryTest extends TestCase
+{
+    use DatabaseTestTrait;
+
+    protected $refresh   = true;
+    protected $namespace = 'Daycry\Auth';
+    private OAuthTokenRepository $repo;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $this->repo    = new OAuthTokenRepository($identityModel);
+    }
+
+    private function createUser(string $username = 'TestUser', string $email = 'test@example.com'): User
+    {
+        $userModel = new UserModel();
+        $user      = new User([
+            'username' => $username,
+            'email'    => $email,
+            'password' => 'password123',
+        ]);
+        $userModel->save($user);
+
+        return $userModel->findById($userModel->getInsertID());
+    }
+
+    public function testFindByUserAndProvider(): void
+    {
+        $user = $this->createUser();
+
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identityModel->insert([
+            'user_id' => $user->id,
+            'type'    => IdentityType::oauthProvider('github'),
+            'name'    => 'TestUser',
+            'secret'  => 'social_123',
+            'secret2' => 'access_token',
+            'extra'   => json_encode(['refresh_token' => 'rt_abc']),
+        ]);
+
+        $identity = $this->repo->findByUserAndProvider((int) $user->id, 'github');
+
+        $this->assertNotNull($identity);
+        $this->assertSame('social_123', $identity->secret);
+    }
+
+    public function testFindByUserAndProviderReturnsNull(): void
+    {
+        $user = $this->createUser();
+
+        $identity = $this->repo->findByUserAndProvider((int) $user->id, 'github');
+
+        $this->assertNull($identity);
+    }
+
+    public function testFindByProviderAndSocialId(): void
+    {
+        $user = $this->createUser();
+
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identityModel->insert([
+            'user_id' => $user->id,
+            'type'    => IdentityType::oauthProvider('google'),
+            'name'    => 'TestUser',
+            'secret'  => 'google_456',
+            'secret2' => 'access_token',
+        ]);
+
+        $identity = $this->repo->findByProviderAndSocialId('google', 'google_456');
+
+        $this->assertNotNull($identity);
+        $this->assertSame((string) $user->id, (string) $identity->user_id);
+    }
+
+    public function testCreateOAuthIdentity(): void
+    {
+        $user = $this->createUser();
+
+        $this->repo->createOAuthIdentity((int) $user->id, 'facebook', [
+            'name'    => 'FBUser',
+            'secret'  => 'fb_789',
+            'secret2' => 'at_xyz',
+            'extra'   => json_encode(['refresh_token' => 'rt_fb']),
+            'expires' => null,
+        ]);
+
+        $this->seeInDatabase('auth_users_identities', [
+            'user_id' => $user->id,
+            'type'    => IdentityType::oauthProvider('facebook'),
+            'secret'  => 'fb_789',
+        ]);
+    }
+
+    public function testUpdateOAuthIdentity(): void
+    {
+        $user = $this->createUser();
+
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identityModel->insert([
+            'user_id' => $user->id,
+            'type'    => IdentityType::oauthProvider('github'),
+            'name'    => 'TestUser',
+            'secret'  => 'social_upd',
+            'secret2' => 'old_token',
+        ]);
+
+        $identity          = $this->repo->findByUserAndProvider((int) $user->id, 'github');
+        $identity->secret2 = 'new_token';
+
+        $this->repo->updateOAuthIdentity($identity);
+
+        $this->seeInDatabase('auth_users_identities', [
+            'secret'  => 'social_upd',
+            'secret2' => 'new_token',
+        ]);
+    }
+
+    public function testGetProfileData(): void
+    {
+        $user = $this->createUser();
+
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identityModel->insert([
+            'user_id' => $user->id,
+            'type'    => IdentityType::oauthProvider('azure'),
+            'name'    => 'AzureUser',
+            'secret'  => 'az_123',
+            'secret2' => 'at_az',
+            'extra'   => json_encode([
+                'refresh_token' => 'rt_az',
+                'profile'       => ['department' => 'Engineering', 'jobTitle' => 'Dev'],
+            ]),
+        ]);
+
+        $profileData = $this->repo->getProfileData((int) $user->id, 'azure');
+
+        $this->assertSame(['department' => 'Engineering', 'jobTitle' => 'Dev'], $profileData);
+    }
+
+    public function testGetProfileDataLegacyExtra(): void
+    {
+        $user = $this->createUser();
+
+        /** @var UserIdentityModel $identityModel */
+        $identityModel = model(UserIdentityModel::class);
+        $identityModel->insert([
+            'user_id' => $user->id,
+            'type'    => IdentityType::oauthProvider('generic'),
+            'name'    => 'LegacyUser',
+            'secret'  => 'legacy_1',
+            'secret2' => 'at_legacy',
+            'extra'   => 'plain_refresh_token',
+        ]);
+
+        $profileData = $this->repo->getProfileData((int) $user->id, 'generic');
+
+        $this->assertSame([], $profileData);
+    }
+
+    public function testParseExtraJson(): void
+    {
+        $extra = json_encode(['refresh_token' => 'rt', 'profile' => ['a' => 1]]);
+
+        $result = $this->repo->parseExtra($extra);
+
+        $this->assertSame('rt', $result['refresh_token']);
+        $this->assertSame(['a' => 1], $result['profile']);
+    }
+
+    public function testParseExtraLegacy(): void
+    {
+        $result = $this->repo->parseExtra('plain_token_string');
+
+        $this->assertSame(['refresh_token' => 'plain_token_string'], $result);
+    }
+
+    public function testParseExtraEmpty(): void
+    {
+        $this->assertSame([], $this->repo->parseExtra(null));
+        $this->assertSame([], $this->repo->parseExtra(''));
+    }
+}

--- a/tests/Traits/BaseControllerTraitTest.php
+++ b/tests/Traits/BaseControllerTraitTest.php
@@ -313,13 +313,11 @@ final class BaseControllerTraitTest extends DatabaseTestCase
         $reflection = new ReflectionClass($this->controller);
 
         $argsProperty = $reflection->getProperty('args');
-        $argsProperty->setAccessible(true);
-        $args = $argsProperty->getValue($this->controller);
+        $args         = $argsProperty->getValue($this->controller);
         $this->assertIsArray($args);
 
         $contentProperty = $reflection->getProperty('content');
-        $contentProperty->setAccessible(true);
-        $content = $contentProperty->getValue($this->controller);
+        $content         = $contentProperty->getValue($this->controller);
         // Content can be null or whatever was in the body
         $this->assertTrue($content === null || is_string($content) || is_array($content));
     }


### PR DESCRIPTION
[5.0.0](https://github.com/daycry/auth/compare/v4.0.0...v5.0.0) - 2026-03-20
Added
OAuth Profile System
IdentityType::oauthProvider() static helper — centralises the oauth_ prefix convention for dynamic provider types. Replaces all manual 'oauth_' . $provider string concatenation across the codebase.
OAuthTokenRepository (src/Models/OAuthTokenRepository.php) — dedicated repository for OAuth identity CRUD, following the same pattern as AccessTokenRepository and JwtTokenRepository. Methods:
findByUserAndProvider(int $userId, string $provider) — find OAuth identity for a user/provider pair
findByProviderAndSocialId(string $provider, string $socialId) — find by provider type and social ID
createOAuthIdentity(int $userId, string $provider, array $data) — insert a new OAuth identity
updateOAuthIdentity(UserIdentity $identity) — update an existing identity (token refresh, re-login)
getProfileData(int $userId, string $provider) — get stored profile data from the extra JSON
parseExtra(?string $extra) — parse extra column with backward compatibility (JSON and legacy plain-string format)
Config-based ProfileResolverFactory — the factory now accepts $providerConfig and resolves profile resolvers in this order:
$providerConfig['profileResolver'] — custom class (must implement ProfileResolverInterface, throws LogicException otherwise)
Built-in map (azure -> AzureProfileResolver)
Fallback -> GenericProfileResolver
profileResolver config key — documented in AuthOAuth.php Generic provider example; allows per-provider custom resolver classes
scopes_granted in extra JSON — when the OAuth provider returns granted scopes in the token response (RFC 6749 SS3.3), they are stored as an array in the identity's extra JSON. Updated on both initial login and token refresh.
profile_fetched_at in extra JSON — ISO 8601 timestamp recorded when profile fields are fetched, allowing consumers to know the freshness of cached profile data
OAuth Events
oauth-login — fired after every successful OAuth login via handleCallback(). Arguments: User $user, string $providerName
oauth-profile-fetched — fired when profile fields were resolved (only when fields is configured and data was returned). Arguments: User $user, string $providerName, array $profileData
Tests
tests/Models/OAuthTokenRepositoryTest.php — 10 tests covering find, create, update, getProfileData, parseExtra (JSON, legacy, empty)
tests/Libraries/Oauth/ProfileResolver/ProfileResolverFactoryTest.php — 4 tests: Azure resolver, generic fallback, config-based override, invalid resolver throws
tests/Libraries/OauthManagerTest.php — 9 new tests:
testRefreshAccessTokenWithJsonExtra / testRefreshAccessTokenWithLegacyExtra — refresh with JSON and legacy extra formats
testRefreshAccessTokenNoIdentity / testRefreshAccessTokenProviderFails — null return cases
testHandleCallbackTriggersOauthLoginEvent / testHandleCallbackTriggersProfileFetchedEvent — event verification
testHandleCallbackStoresScopesGranted — scopes extracted from token response
testHandleCallbackStoresProfileFetchedAt — timestamp presence in extra JSON
Documentation
docs/09-oauth.md — complete rewrite with 11 new sections: Architecture, Stored Token Data (JSON structure), Profile Fields (configuring, resolvers, custom resolver, reading data), Scopes Granted, OAuth Events, OAuthTokenRepository reference, IdentityType Helper, Testing OAuth
docs/02-configuration.md — updated OAuth section with fields, fieldsEndpoint, profileResolver keys; added Provider Configuration Keys reference table
docs/07-logging.md — added oauth-login and oauth-profile-fetched to the events table; added OAuth Login Tracking section
docs/08-testing.md — added OAuth test file references
docs/README.md — added OAuth Profile Fields & Resolvers, OAuth Events, OAuthTokenRepository to Feature Matrix
docs/index.md — updated OAuth description
CLAUDE.md — added OAuthTokenRepository to source layout and token repositories table; expanded OAuth2 section
Changed
OauthManager refactored — all identity CRUD delegated to OAuthTokenRepository via lazy-initialised getRepository() getter. Centralised getIdentityModel() replaces three separate model(UserIdentityModel::class) calls. Removed private parseExtra() method (now public on repository).
ProfileResolverFactory::create() signature — now accepts optional array $providerConfig = [] as second parameter for config-based resolver resolution
OauthManager::processUser() — login event (auth()->login()) no longer triggers events itself; oauth-login and oauth-profile-fetched are fired from handleCallback() after processUser() returns
OauthManager::refreshAccessToken() — now updates scopes_granted in extra JSON when the refreshed token includes scope information
PHPStan baseline regenerated: 599 -> 627 suppressions (new repository, tests, Mockery patterns)