### PR TITLE
docs: colorize HTTP examples + fix leftover admonition

### DIFF
--- a/docs/03-authentication.md
+++ b/docs/03-authentication.md
@@ -329,7 +329,7 @@ X-API-KEY: your_raw_token_here
 
 Or via query string:
 
-```text
+```http
 GET /api/users?token=your_raw_token_here
 ```
 
@@ -534,7 +534,7 @@ public int $jwtRefreshLifetime = 30 * DAY; // Refresh token validity
 
 ### Login
 
-```text
+```http
 POST /auth/jwt/login
 Content-Type: application/x-www-form-urlencoded
 
@@ -554,7 +554,7 @@ email=user@example.com&password=secret
 
 ### Refresh an Expired Access Token
 
-```text
+```http
 POST /auth/jwt/refresh
 Content-Type: application/x-www-form-urlencoded
 
@@ -576,7 +576,7 @@ user_id=42&refresh_token=a3f8c2d1e4b7...
 
 ### Logout (Revoke Refresh Token)
 
-```text
+```http
 POST /auth/jwt/logout
 Content-Type: application/x-www-form-urlencoded
 

--- a/docs/11-device-sessions.md
+++ b/docs/11-device-sessions.md
@@ -494,14 +494,12 @@ class DeviceSessionTest extends DatabaseTestCase
 
 ## Security Tips
 
-```{admonition} Best Practices
-:class: tip
+!!! tip "Best Practices"
 
-- Always use the `uuid` column when referencing sessions in URLs or API responses — never expose the integer `id`.
-- Show the user a "when and from where" summary so they can spot unfamiliar sessions.
-- Consider sending an email notification on new device logins for high-security applications.
-- Pair device sessions with per-user account lockout for defense in depth.
-```
+    - Always use the `uuid` column when referencing sessions in URLs or API responses — never expose the integer `id`.
+    - Show the user a "when and from where" summary so they can spot unfamiliar sessions.
+    - Consider sending an email notification on new device logins for high-security applications.
+    - Pair device sessions with per-user account lockout for defense in depth.
 
 ---
 


### PR DESCRIPTION
Answers "can all the code blocks be colorful?":

- **All real code already highlights** (php ×298, bash ×34, html, json, js, http — 0 untagged blocks).
- Retags the **4 raw HTTP request examples** (`03-authentication.md`) `text` → `http` so they colorize (they were only `text` to silence a Sphinx-era lexer warning that doesn't apply under MkDocs).
- Fixes a **leftover MyST `{admonition} Best Practices`** block in `11-device-sessions.md` (missed during the MkDocs migration) → now a Material `!!! tip` admonition instead of a broken code block.

The remaining plaintext blocks are genuine **flow diagrams, permission-name lists, a permissions tree, route→handler listings and a file path** — not a programming language — so they correctly stay `text` (forcing a language would mis-highlight). Those flow diagrams could later be upgraded to rendered **Mermaid** flowcharts if desired.

Verified locally: `mkdocs build --strict` succeeds (0 warnings); the admonition renders as a tip and the HTTP blocks carry `language-http`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)