### PR TITLE
docs: fix PHP syntax highlighting (tag-less snippets)

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -84,6 +84,15 @@ markdown_extensions:
       anchor_linenums: true
       line_spans: __span
       pygments_lang_class: true
+      # The docs' PHP snippets omit the opening `<?php` tag, so Pygments' PHP
+      # lexer would treat them as plain HTML (all "Other" tokens, no colour).
+      # Re-define the `php` fence to run the lexer in inline mode so bare PHP
+      # highlights correctly.
+      extend_pygments_lang:
+        - name: php
+          lang: php
+          options:
+            startinline: true
   - pymdownx.tabbed:
       alternate_style: true
   - pymdownx.tasklist:


### PR DESCRIPTION
**Fixes "the code isn't colored / text doesn't stand out against the background."**

The docs' PHP examples omit the opening `<?php` tag (normal for snippets). Pygments' PHP lexer only highlights code **inside `<?php ?>`**, so it treated every block as plain HTML — all `Token.Other` (`x`) spans, which Material renders with no colour. That left ~298 PHP blocks (the bulk of the docs) monochrome and low-contrast.

Fix: re-define the `php` fence via pymdownx `extend_pygments_lang` to run the lexer with `startinline: true`.

Before: a php block = 457× `<span class="x">` (uncolored).
After: proper tokens — `k` (keywords), `nv` (`$variables`), `s1` (strings), `o`, `nf` (functions), `c1` (comments), `p`, `nx`, `mi`…

Verified locally: `mkdocs build --strict` succeeds and PHP blocks emit the full range of token classes. bash/json/html/http were already highlighting correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)