### PR TITLE
fix: honor soft-deletes in authentication and RBAC

### DIFF
--- a/docs/03-authentication.md
+++ b/docs/03-authentication.md
@@ -233,6 +233,32 @@ model(\Daycry\Auth\Models\UserModel::class)->update($userId, [
 
 ---
 
+## Deleted Users
+
+`UserModel` hard-deletes by default (`$useSoftDeletes = false`), so deleting a
+user physically removes the row — there is nothing left to authenticate. The
+`users.deleted_at` column exists for consumers who enable **soft-deletes** (by
+extending `UserModel` with `$useSoftDeletes = true`). When `deleted_at` is set,
+the user is rejected by **every** authenticator, exactly like a hard-deleted or
+banned user:
+
+| Authenticator | How a soft-deleted user is rejected |
+|---------------|--------------------------------------|
+| **Session** | `findByCredentials()` / `findById()` apply the soft-delete scope (`deleted_at IS NULL`) |
+| **JWT** | resolves the user via `findById()`, which applies the same scope |
+| **Access Token** | the eager token+user JOIN re-applies a `deleted_at` guard, so this bypass path stays consistent with Session/JWT |
+
+The Access Token guard is **config-agnostic** — it filters `deleted_at`
+unconditionally, so it is a no-op under hard-delete (the row is already gone)
+and correct the moment soft-deletes are enabled. The same principle extends to
+the RBAC tables — see
+[Authorization → Soft-Deleted Records](06-authorization.md#soft-deleted-records).
+
+> To keep a user's record but block login **without** soft-deletes, prefer
+> `$user->ban()` (sets `status = 'banned'`) or `active = false`.
+
+---
+
 ## Compromised-Password Recheck on Login
 
 Optional opt-in: after a successful password verification, re-test the live password against [HaveIBeenPwned](https://haveibeenpwned.com/) and flag the account for forced reset if it appears in a known breach corpus.

--- a/docs/06-authorization.md
+++ b/docs/06-authorization.md
@@ -13,6 +13,7 @@ Both are stored in the database and can be assigned freely to any user.
 - [Groups](#groups)
 - [Permissions](#permissions)
 - [Permission Inheritance](#permission-inheritance)
+- [Soft-Deleted Records](#soft-deleted-records)
 - [Gates & Policies](#gates--policies)
 - [Gate → RBAC Bridge](#gate--rbac-bridge)
 - [Resolvable Repository Services](#resolvable-repository-services)
@@ -246,6 +247,35 @@ $user->can('users.view');   // true
 > `$user->addPermission('posts.*')`) now correctly grants `posts.create`,
 > `posts.edit`, etc. Earlier versions only expanded scope wildcards that were
 > inherited from a group; direct wildcards required an exact-string match.
+
+---
+
+## Soft-Deleted Records
+
+Every RBAC table — `auth_groups`, `auth_permissions`, and the three pivots
+`auth_groups_users`, `auth_permissions_users`, `auth_permissions_groups` — ships
+with a `deleted_at` column. The models hard-delete by default
+(`$useSoftDeletes = false`), so that column stays `null`. If you enable
+**soft-deletes** (extend a model and set `$useSoftDeletes = true`, or write
+`deleted_at` yourself), a soft-deleted row is treated as gone for **every
+authorization decision**, exactly like a hard-deleted one:
+
+| Soft-deleted record | Effect |
+|---------------------|--------|
+| A **group** (`auth_groups`) | drops every member's membership — `inGroup()`, `getGroups()` and its inherited permissions stop counting it; it can no longer be (re-)assigned via `addGroup()` |
+| A **permission** (`auth_permissions`) | stops being granted via `can()` / `getPermissions()`, whether assigned directly or inherited, and can no longer be (re-)assigned via `addPermission()` |
+| A **pivot row** (`*_users`, `permissions_groups`) | drops just that one assignment — the group / permission itself and every other user stay untouched |
+
+The exclusion is **config-agnostic**: the RBAC read queries filter
+`deleted_at IS NULL` unconditionally, so it is a no-op under the default
+hard-delete behaviour (the row is already gone) and automatically correct once
+soft-deletes are in play. This mirrors how a soft-deleted **user** is locked out
+of every authenticator — see
+[Authentication → Deleted Users](03-authentication.md#deleted-users).
+
+> **Admin panel**: the management screens still list every record (including
+> soft-deleted ones) so they can be reviewed or restored. The exclusion applies
+> to authorization *use*, not to administrative listing.
 
 ---
 

--- a/src/Models/AccessTokenRepository.php
+++ b/src/Models/AccessTokenRepository.php
@@ -136,6 +136,16 @@ class AccessTokenRepository
             }
         }
 
+        // A non-null deleted_at means the owning user was (soft-)deleted. The
+        // Session and JWT paths resolve the user through UserModel::find()/first(),
+        // which honour the soft-delete scope; this eager JOIN runs on
+        // UserIdentityModel and bypasses it, so we re-apply the guard here. The
+        // check is a no-op when soft-deletes are disabled (hard-delete removes
+        // the row, so deleted_at is always null then).
+        if (($userData['deleted_at'] ?? null) !== null) {
+            return null;
+        }
+
         // Build the User from the joined columns. Leaving its identities null
         // (DO NOT call setIdentities([])) keeps lazy-loading behaviour identical
         // to a findById() User.

--- a/src/Models/GroupModel.php
+++ b/src/Models/GroupModel.php
@@ -53,7 +53,7 @@ class GroupModel extends BaseModel
         // authorization decision. Config-agnostic: a no-op when soft-deletes
         // are disabled (hard-delete removes the row, so deleted_at is null).
         return $this->whereIn('id', $groupIds)
-            ->where($this->deletedField, null)
+            ->where($this->deletedField)
             ->orderBy($this->primaryKey)
             ->findAll();
     }

--- a/src/Models/GroupModel.php
+++ b/src/Models/GroupModel.php
@@ -49,6 +49,12 @@ class GroupModel extends BaseModel
      */
     public function getByIds(array $groupIds): array
     {
-        return $this->whereIn('id', $groupIds)->orderBy($this->primaryKey)->findAll();
+        // Exclude (soft-)deleted groups so they never participate in an
+        // authorization decision. Config-agnostic: a no-op when soft-deletes
+        // are disabled (hard-delete removes the row, so deleted_at is null).
+        return $this->whereIn('id', $groupIds)
+            ->where($this->deletedField, null)
+            ->orderBy($this->primaryKey)
+            ->findAll();
     }
 }

--- a/src/Models/GroupUserModel.php
+++ b/src/Models/GroupUserModel.php
@@ -50,6 +50,7 @@ class GroupUserModel extends BaseModel
         $now = Time::now()->format('Y-m-d H:i:s');
 
         return $this->where('user_id', $user->id)
+            ->where($this->deletedField, null)
             ->groupStart()
             ->where('until_at IS NULL')
             ->orWhere('until_at >', $now)

--- a/src/Models/GroupUserModel.php
+++ b/src/Models/GroupUserModel.php
@@ -50,7 +50,7 @@ class GroupUserModel extends BaseModel
         $now = Time::now()->format('Y-m-d H:i:s');
 
         return $this->where('user_id', $user->id)
-            ->where($this->deletedField, null)
+            ->where($this->deletedField)
             ->groupStart()
             ->where('until_at IS NULL')
             ->orWhere('until_at >', $now)

--- a/src/Models/PermissionGroupModel.php
+++ b/src/Models/PermissionGroupModel.php
@@ -52,6 +52,7 @@ class PermissionGroupModel extends BaseModel
         $now = Time::now()->format('Y-m-d H:i:s');
 
         return $this->where('group_id', $group->id)
+            ->where($this->deletedField, null)
             ->groupStart()
             ->where('until_at')
             ->orWhere('until_at >', $now)

--- a/src/Models/PermissionGroupModel.php
+++ b/src/Models/PermissionGroupModel.php
@@ -52,7 +52,7 @@ class PermissionGroupModel extends BaseModel
         $now = Time::now()->format('Y-m-d H:i:s');
 
         return $this->where('group_id', $group->id)
-            ->where($this->deletedField, null)
+            ->where($this->deletedField)
             ->groupStart()
             ->where('until_at')
             ->orWhere('until_at >', $now)

--- a/src/Models/PermissionModel.php
+++ b/src/Models/PermissionModel.php
@@ -50,7 +50,7 @@ class PermissionModel extends BaseModel
         // authorization decision. Config-agnostic: a no-op when soft-deletes
         // are disabled (hard-delete removes the row, so deleted_at is null).
         return $this->whereIn('id', $permissionIds)
-            ->where($this->deletedField, null)
+            ->where($this->deletedField)
             ->orderBy($this->primaryKey)
             ->findAll();
     }

--- a/src/Models/PermissionModel.php
+++ b/src/Models/PermissionModel.php
@@ -46,6 +46,12 @@ class PermissionModel extends BaseModel
      */
     public function getByIds(array $permissionIds): array
     {
-        return $this->whereIn('id', $permissionIds)->orderBy($this->primaryKey)->findAll();
+        // Exclude (soft-)deleted permissions so they never participate in an
+        // authorization decision. Config-agnostic: a no-op when soft-deletes
+        // are disabled (hard-delete removes the row, so deleted_at is null).
+        return $this->whereIn('id', $permissionIds)
+            ->where($this->deletedField, null)
+            ->orderBy($this->primaryKey)
+            ->findAll();
     }
 }

--- a/src/Models/PermissionUserModel.php
+++ b/src/Models/PermissionUserModel.php
@@ -52,6 +52,7 @@ class PermissionUserModel extends BaseModel
         $now = Time::now()->format('Y-m-d H:i:s');
 
         return $this->where('user_id', $user->id)
+            ->where($this->deletedField, null)
             ->groupStart()
             ->where('until_at IS NULL')
             ->orWhere('until_at >', $now)

--- a/src/Models/PermissionUserModel.php
+++ b/src/Models/PermissionUserModel.php
@@ -52,7 +52,7 @@ class PermissionUserModel extends BaseModel
         $now = Time::now()->format('Y-m-d H:i:s');
 
         return $this->where('user_id', $user->id)
-            ->where($this->deletedField, null)
+            ->where($this->deletedField)
             ->groupStart()
             ->where('until_at IS NULL')
             ->orWhere('until_at >', $now)

--- a/src/Traits/Authorizable.php
+++ b/src/Traits/Authorizable.php
@@ -528,6 +528,7 @@ trait Authorizable
 
         $allGroupPerms = $groupPermModel
             ->whereIn('group_id', $groupIds)
+            ->where('deleted_at', null)
             ->groupStart()
             ->where('until_at')
             ->orWhere('until_at >', $now)
@@ -598,7 +599,9 @@ trait Authorizable
         }
 
         $groupModel = $this->groupModel();
-        $rows       = $groupModel->findAll();
+        // Exclude (soft-)deleted groups from the valid-groups map so they can be
+        // neither used in checks nor (re-)assigned. No-op under hard-delete.
+        $rows = $groupModel->where('deleted_at', null)->findAll();
 
         foreach ($rows as $row) {
             $this->groups[$row->id] = $row->name;
@@ -649,7 +652,10 @@ trait Authorizable
         }
 
         $permissionModel = $this->permissionModel();
-        $rows            = $permissionModel->findAll();
+        // Exclude (soft-)deleted permissions from the valid-permissions map so
+        // they can be neither used in checks nor (re-)assigned. No-op under
+        // hard-delete.
+        $rows = $permissionModel->where('deleted_at', null)->findAll();
 
         foreach ($rows as $row) {
             $this->permissions[$row->id] = $row->name;

--- a/src/Traits/Authorizable.php
+++ b/src/Traits/Authorizable.php
@@ -528,7 +528,7 @@ trait Authorizable
 
         $allGroupPerms = $groupPermModel
             ->whereIn('group_id', $groupIds)
-            ->where('deleted_at', null)
+            ->where('deleted_at')
             ->groupStart()
             ->where('until_at')
             ->orWhere('until_at >', $now)
@@ -601,7 +601,7 @@ trait Authorizable
         $groupModel = $this->groupModel();
         // Exclude (soft-)deleted groups from the valid-groups map so they can be
         // neither used in checks nor (re-)assigned. No-op under hard-delete.
-        $rows = $groupModel->where('deleted_at', null)->findAll();
+        $rows = $groupModel->where('deleted_at')->findAll();
 
         foreach ($rows as $row) {
             $this->groups[$row->id] = $row->name;
@@ -655,7 +655,7 @@ trait Authorizable
         // Exclude (soft-)deleted permissions from the valid-permissions map so
         // they can be neither used in checks nor (re-)assigned. No-op under
         // hard-delete.
-        $rows = $permissionModel->where('deleted_at', null)->findAll();
+        $rows = $permissionModel->where('deleted_at')->findAll();
 
         foreach ($rows as $row) {
             $this->permissions[$row->id] = $row->name;

--- a/tests/Authorization/SoftDeletedRbacTest.php
+++ b/tests/Authorization/SoftDeletedRbacTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Tests\Authorization;
 
 use CodeIgniter\I18n\Time;
+use Daycry\Auth\Entities\Group;
 use Daycry\Auth\Entities\User;
 use Daycry\Auth\Exceptions\AuthorizationException;
 use Daycry\Auth\Models\GroupModel;
@@ -164,7 +165,7 @@ final class SoftDeletedRbacTest extends DatabaseTestCase
             'created_at'    => Time::now()->toDateTimeString(),
         ]);
 
-        /** @var \Daycry\Auth\Entities\Group $group */
+        /** @var Group $group */
         $group = model(GroupModel::class)->find(1);
 
         $this->assertCount(1, model(PermissionGroupModel::class)->getForGroup($group));

--- a/tests/Authorization/SoftDeletedRbacTest.php
+++ b/tests/Authorization/SoftDeletedRbacTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Daycry Auth.
+ *
+ * (c) Daycry <daycry9@proton.me>
+ *
+ * For the full copyright and license information, please view
+ * the LICENSE file that was distributed with this source code.
+ */
+
+namespace Tests\Authorization;
+
+use CodeIgniter\I18n\Time;
+use Daycry\Auth\Entities\User;
+use Daycry\Auth\Exceptions\AuthorizationException;
+use Daycry\Auth\Models\GroupModel;
+use Daycry\Auth\Models\PermissionGroupModel;
+use Daycry\Auth\Models\PermissionModel;
+use Daycry\Auth\Models\UserModel;
+use Tests\Support\DatabaseTestCase;
+use Tests\Support\FakeUser;
+
+/**
+ * A (soft-)deleted RBAC row — a group, a permission, or any of the three
+ * pivot rows (groups_users, permissions_users, permissions_groups) — must
+ * never participate in an authorization decision, exactly like a hard-deleted
+ * row would not. The guard is config-agnostic: with hard-delete the row is
+ * gone (deleted_at always null), so these checks are a no-op; with soft-delete
+ * enabled they exclude the soft-deleted row.
+ *
+ * @internal
+ */
+final class SoftDeletedRbacTest extends DatabaseTestCase
+{
+    use FakeUser;
+
+    protected $refresh = true;
+
+    /**
+     * A fresh User entity with empty in-memory group/permission caches, so each
+     * assertion reads RBAC state straight from the database.
+     */
+    private function freshUser(): User
+    {
+        /** @var User $user */
+        $user = model(UserModel::class)->find($this->user->id);
+
+        return $user;
+    }
+
+    /**
+     * Marks matching rows of an Auth table as soft-deleted.
+     *
+     * @param array<string, int|string> $where
+     */
+    private function softDelete(string $tableKey, array $where): void
+    {
+        $this->db->table($this->tables[$tableKey])
+            ->where($where)
+            ->update(['deleted_at' => Time::now()->format('Y-m-d H:i:s')]);
+    }
+
+    public function testSoftDeletedGroupDropsMembership(): void
+    {
+        $this->user->addGroup('admin');
+
+        // Sanity: the membership is active before the group is soft-deleted.
+        $this->assertTrue($this->freshUser()->inGroup('admin'));
+
+        $this->softDelete('groups', ['id' => 1]);
+
+        $fresh = $this->freshUser();
+        $this->assertFalse($fresh->inGroup('admin'));
+        $this->assertNotContains('admin', $fresh->getGroups());
+    }
+
+    public function testSoftDeletedGroupUserPivotDropsMembership(): void
+    {
+        $this->user->addGroup('admin');
+
+        $this->assertTrue($this->freshUser()->inGroup('admin'));
+
+        $this->softDelete('groups_users', ['user_id' => $this->user->id, 'group_id' => 1]);
+
+        $this->assertFalse($this->freshUser()->inGroup('admin'));
+    }
+
+    public function testSoftDeletedPermissionRevokesDirectPermission(): void
+    {
+        $permission = fake(PermissionModel::class, ['name' => 'admin.access']);
+        $this->user->addPermission('admin.access');
+
+        $this->assertTrue($this->freshUser()->can('admin.access'));
+
+        $this->softDelete('permissions', ['id' => $permission->id]);
+
+        $fresh = $this->freshUser();
+        $this->assertFalse($fresh->can('admin.access'));
+        $this->assertNotContains('admin.access', $fresh->getPermissions());
+    }
+
+    public function testSoftDeletedPermissionUserPivotRevokesDirectPermission(): void
+    {
+        fake(PermissionModel::class, ['name' => 'admin.access']);
+        $this->user->addPermission('admin.access');
+
+        $this->assertTrue($this->freshUser()->can('admin.access'));
+
+        $this->softDelete('permissions_users', ['user_id' => $this->user->id]);
+
+        $this->assertFalse($this->freshUser()->can('admin.access'));
+    }
+
+    public function testSoftDeletedPermissionGroupPivotRevokesGroupPermission(): void
+    {
+        $permission = fake(PermissionModel::class, ['name' => 'admin.access']);
+
+        $this->hasInDatabase($this->tables['permissions_groups'], [
+            'group_id'      => 1,
+            'permission_id' => $permission->id,
+            'created_at'    => Time::now()->toDateTimeString(),
+        ]);
+
+        $this->user->addGroup('admin');
+
+        $this->assertTrue($this->freshUser()->can('admin.access'));
+
+        $this->softDelete('permissions_groups', ['group_id' => 1, 'permission_id' => $permission->id]);
+
+        $this->assertFalse($this->freshUser()->can('admin.access'));
+    }
+
+    public function testSoftDeletedPermissionRevokesGroupCascade(): void
+    {
+        $permission = fake(PermissionModel::class, ['name' => 'admin.access']);
+
+        $this->hasInDatabase($this->tables['permissions_groups'], [
+            'group_id'      => 1,
+            'permission_id' => $permission->id,
+            'created_at'    => Time::now()->toDateTimeString(),
+        ]);
+
+        $this->user->addGroup('admin');
+
+        $this->assertTrue($this->freshUser()->can('admin.access'));
+
+        // Soft-delete the permission row itself (the pivot stays): the group
+        // cascade must drop it because the permission name can no longer resolve.
+        $this->softDelete('permissions', ['id' => $permission->id]);
+
+        $this->assertFalse($this->freshUser()->can('admin.access'));
+    }
+
+    public function testGetForGroupExcludesSoftDeletedPivot(): void
+    {
+        $permission = fake(PermissionModel::class, ['name' => 'admin.access']);
+
+        $this->hasInDatabase($this->tables['permissions_groups'], [
+            'group_id'      => 1,
+            'permission_id' => $permission->id,
+            'created_at'    => Time::now()->toDateTimeString(),
+        ]);
+
+        /** @var \Daycry\Auth\Entities\Group $group */
+        $group = model(GroupModel::class)->find(1);
+
+        $this->assertCount(1, model(PermissionGroupModel::class)->getForGroup($group));
+
+        $this->softDelete('permissions_groups', ['group_id' => 1, 'permission_id' => $permission->id]);
+
+        $this->assertCount(0, model(PermissionGroupModel::class)->getForGroup($group));
+    }
+
+    public function testCannotAddSoftDeletedGroup(): void
+    {
+        $beta = fake(GroupModel::class, ['name' => 'beta']);
+        $this->softDelete('groups', ['id' => $beta->id]);
+
+        $this->expectException(AuthorizationException::class);
+        $this->freshUser()->addGroup('beta');
+    }
+
+    public function testCannotAddSoftDeletedPermission(): void
+    {
+        $permission = fake(PermissionModel::class, ['name' => 'reports.view']);
+        $this->softDelete('permissions', ['id' => $permission->id]);
+
+        $this->expectException(AuthorizationException::class);
+        $this->freshUser()->addPermission('reports.view');
+    }
+}

--- a/tests/Models/AccessTokenRepositoryTest.php
+++ b/tests/Models/AccessTokenRepositoryTest.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Tests\Models;
 
+use CodeIgniter\I18n\Time;
 use Daycry\Auth\Authentication\Authenticators\AccessToken;
 use Daycry\Auth\Entities\User;
 use Daycry\Auth\Models\AccessTokenRepository;
@@ -163,6 +164,28 @@ final class AccessTokenRepositoryTest extends DatabaseTestCase
     public function testGetAccessTokenByRawTokenReturnsNullForUnknown(): void
     {
         $this->assertNotInstanceOf(\Daycry\Auth\Entities\AccessToken::class, $this->repo->getAccessTokenByRawToken('totally-unknown-raw-token'));
+    }
+
+    public function testGetAccessTokenByRawTokenWithUserDeniesSoftDeletedUser(): void
+    {
+        $user  = $this->makeUser();
+        $token = $this->repo->generateAccessToken($user, 'mobile');
+
+        // Sanity: while the user is active, the eager JOIN resolves the token.
+        $this->assertInstanceOf(
+            \Daycry\Auth\Entities\AccessToken::class,
+            $this->repo->getAccessTokenByRawTokenWithUser($token->raw_token),
+        );
+
+        // Simulate a soft-deleted user: deleted_at set on the users row (this is
+        // what a UserModel subclass with $useSoftDeletes = true would write).
+        // The access-token path must honour it the same way Session/JWT do —
+        // a (soft-)deleted user can no longer authenticate via their token.
+        $this->db->table($this->tables['users'])
+            ->where('id', $user->id)
+            ->update(['deleted_at' => Time::now()->format('Y-m-d H:i:s')]);
+
+        $this->assertNull($this->repo->getAccessTokenByRawTokenWithUser($token->raw_token));
     }
 
     public function testGenerateAccessTokenDefaultsToWildcardScope(): void


### PR DESCRIPTION
## Summary

A soft-deleted record (a row with `deleted_at` set) was still being **used** in two places where a hard-deleted row never would be. This makes both consistent: a soft-deleted user can no longer authenticate, and soft-deleted RBAC rows no longer grant access — exactly like a hard-delete.

Both fixes use the same **config-agnostic guard**: the read filters `deleted_at IS NULL` unconditionally, so it is a **no-op under the default hard-delete** (the row is already gone, `deleted_at` is always null) and becomes correct the moment a consumer enables soft-deletes (by extending a model with `$useSoftDeletes = true`, or by writing `deleted_at` directly).

## Changes

### 1. Access-token authentication (`fix(auth)`)
`AccessTokenRepository::getAccessTokenByRawTokenWithUser()` eager-loads the owning user via a raw JOIN on `UserIdentityModel`, bypassing `UserModel`'s soft-delete scope. Session (`findByCredentials`/`findById`) and JWT (`findById`) already rejected soft-deleted users; the access-token path did not. Added a guard that returns `null` when the joined user row's `deleted_at` is non-null.

### 2. RBAC authorization (`fix(authorization)`)
Groups, permissions and the three pivots (`groups_users`, `permissions_users`, `permissions_groups`) all carry `deleted_at`, but the RBAC read queries never filtered it. Added `deleted_at IS NULL` guards to every read path:
- `GroupModel::getByIds`, `PermissionModel::getByIds`
- `GroupUserModel::getForUser`, `PermissionUserModel::getForUser`, `PermissionGroupModel::getForGroup`
- `Authorizable::populateGroups` / `populatePermissions` (valid-record maps) and `eagerLoadGroupPermissions` (group→permission cascade used by `can()`)

A soft-deleted group/permission/assignment is now ignored by `can()`, `inGroup()`, `hasPermission()`, `getGroups()`, `getPermissions()` and can no longer be (re-)assigned.

### Scope note
The admin-panel management screens still list every record (including soft-deleted ones) so they can be reviewed/restored — the exclusion applies to authorization **use**, not administrative listing.

## Tests
- New `tests/Authorization/SoftDeletedRbacTest.php` — 9 tests covering all 5 RBAC tables (group, permission, and the 3 pivots), plus the add/re-assign guards.
- New case in `tests/Models/AccessTokenRepositoryTest.php` — a soft-deleted user cannot authenticate via access token.
- Written test-first (RED → GREEN).

## Verification
- ✅ PHPUnit: **1079 tests** pass (1 pre-existing skip)
- ✅ PHPStan level 5: no errors
- ✅ `mkdocs build --strict`: no warnings

## Docs
- `docs/03-authentication.md` → "Deleted Users" section (per-authenticator behavior table)
- `docs/06-authorization.md` → "Soft-Deleted Records" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)